### PR TITLE
Add get_slice for IDL data

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -206,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can take a slice at a given location:"
+    "We can take a slice at a given location, which works both for IDL and AMReX data:"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flekspy"
-version = "0.2.1"
+version = "0.2.2"
 description = "Python utilities for processing FLEKS data"
 authors = ["Yuxi Chen <yuxichen@umich.edu>, Hongyang Zhou <hyzhou@umich.edu>"]
 readme = "README.md"

--- a/src/flekspy/idl/idl.py
+++ b/src/flekspy/idl/idl.py
@@ -68,7 +68,6 @@ class IDLData(object):
     Example:
     >>> ds = IDLData("3d.out")
     >>> dc2d = ds.get_slice("y", 1)
-    >>> dc3d = ds.get_domain()
     """
 
     def __init__(self, filename="none"):
@@ -129,9 +128,7 @@ class IDLData(object):
         return str
 
     def get_domain(self) -> DataContainer:
-        r"""
-        Return data as data container.
-        """
+        """Return data as data container."""
         dataSets = {}
         for varname in self.data.name:
             idx = self.data.name.index(varname)

--- a/src/flekspy/idl/idl.py
+++ b/src/flekspy/idl/idl.py
@@ -5,7 +5,12 @@ import struct
 import yt
 
 from flekspy.util import get_unit
-from flekspy.util import DataContainer1D, DataContainer2D, DataContainer3D
+from flekspy.util import (
+    DataContainer,
+    DataContainer1D,
+    DataContainer2D,
+    DataContainer3D,
+)
 
 x_ = 0
 y_ = 1
@@ -123,9 +128,9 @@ class IDLData(object):
         )
         return str
 
-    def get_domain(self) -> DataContainer3D:
+    def get_domain(self) -> DataContainer:
         r"""
-        Returns all the 3D data.
+        Return data as data container.
         """
         dataSets = {}
         for varname in self.data.name:
@@ -148,7 +153,7 @@ class IDLData(object):
                     self.data.array[idx, :, :, :], unit, registry=self.registry
                 )
 
-        if self.gencoord:
+        if self.gencoord and self.ndim == 2:
             dc = DataContainer2D(
                 dataSets,
                 np.squeeze(axes[0]),
@@ -192,6 +197,23 @@ class IDLData(object):
             )
 
         return dc
+
+    def get_slice(self, norm, cut_loc) -> DataContainer2D:
+        """Get a 2D slice from the 3D IDL data.
+
+        Args:
+            norm: str
+                The normal direction of the slice from "x", "y" or "z"
+
+            cur_loc: float
+                The position of slicing.
+
+        Return: DataContainer2D
+        """
+        domain = self.get_domain()
+        ds = domain.get_slice(norm, cut_loc)
+
+        return ds
 
     def save_data(self, saveName, saveFormat="ascii"):
         # Currently only support ascii output.

--- a/src/flekspy/util/data_container.py
+++ b/src/flekspy/util/data_container.py
@@ -227,8 +227,7 @@ class DataContainer3D(DataContainer):
         )
 
     def get_slice(self, norm, cut_loc) -> "DataContainer2D":
-        r"""
-        Get a 2D slice from the 3D box data.
+        """Get a 2D slice from the 3D box data.
 
         Args:
             norm: str

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -29,6 +29,7 @@ class TestIDL:
     files = (
         "1d__raw_2_t25.60000_n00000258.out",
         "z=0_fluid_region0_0_t00001640_n00010142.out",
+        "3d_raw.out",
     )
     files = [os.path.join("tests/data/", file) for file in files]
 
@@ -48,6 +49,12 @@ class TestIDL:
         sat = np.array([[-28000.0, 0.0], [9000.0, 0.0]])
         d = ds.extract_data(sat)
         assert d[0][1] == 0.0
+
+    def test_slice(self):
+        ds = flekspy.load(self.files[2])
+        slice = ds.get_slice("z", 0.0)
+        assert slice.dimensions == (8, 8)
+        assert slice.data["absdivB"][2, 3].value == np.float32(3.3033288e-05)
 
     def test_plot(self):
         ds = flekspy.load(self.files[0])
@@ -71,7 +78,7 @@ class TestAMReX:
         ds = flekspy.load(self.files[1])
         assert ds.domain_left_edge[0].v == -0.016
         dc = ds.get_slice("z", 0.5)
-        assert dc.data["particle_id"][0].value == 216050.
+        assert dc.data["particle_id"][0].value == 216050.0
         assert dc.__repr__().startswith("variables")
 
     def test_phase(self):


### PR DESCRIPTION
Convert IDL data to DataContainer and take slices. We already have this method for YT outputs.

One thing we need to consider is if we need a unified internal representation of data for both IDL and YT outputs. Currently we sometimes convert the data to `DataContainer` type, sometime not, especially when we use the YT-related functionalities.