### PR TITLE
Refactor test particles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flekspy"
-version = "0.2.14"
+version = "0.3.0"
 description = "Python utilities for processing FLEKS data"
 authors = ["Yuxi Chen <yuxichen@umich.edu>, Hongyang Zhou <hyzhou@umich.edu>"]
 readme = "README.md"

--- a/src/flekspy/tp/__init__.py
+++ b/src/flekspy/tp/__init__.py
@@ -1,1 +1,1 @@
-from .test_particles import FLEKSTP
+from .test_particles import FLEKSTP, Indices, ParticleTrajectory

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -108,38 +108,6 @@ class ParticleTrajectory:
                 f"Unknown key: '{key}'. Valid keys include {list(component_map.keys()) + list(vector_map.keys())}"
             )
 
-    def get_vector(self, vector_type: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """
-        A generic function to get vector components from a ParticleTrajectory.
-
-        Args:
-            pt (ParticleTrajectory): The particle trajectory object.
-            vector_type (str): The type of vector to retrieve. Valid options are:
-                               "x", "v", "b", "e".
-
-        Returns:
-            A tuple containing the three vector component arrays (e.g., x, y, z).
-        """
-        component_map = {
-            "x": ("x", "y", "z"),
-            "v": ("u", "v", "w"),
-            "b": ("bx", "by", "bz"),
-            "e": ("ex", "ey", "ez"),
-        }
-
-        if vector_type not in component_map:
-            raise ValueError(
-                f"Unknown vector_type: '{vector_type}'. "
-                f"Valid options are {list(component_map.keys())}"
-            )
-
-        components = component_map[vector_type]
-        c1 = self[components[0]]
-        c2 = self[components[1]]
-        c3 = self[components[2]]
-
-        return c1, c2, c3
-
 
 class FLEKSTP(object):
     """
@@ -472,8 +440,8 @@ class FLEKSTP(object):
 
     def get_pitch_angle(self, pID):
         pt = self.read_particle_trajectory(pID)
-        vx, vy, vz = pt.get_vector("v")
-        bx, by, bz = pt.get_vector("b")
+        vx, vy, vz = pt["velocity"]
+        bx, by, bz = pt["b"]
         # Pitch Angle Calculation
         pitch_angle = self.get_pitch_angle_from_v_b(vx, vy, vz, bx, by, bz)
 
@@ -509,8 +477,8 @@ class FLEKSTP(object):
 
     def get_first_adiabatic_invariant(self, pID, mass=proton_mass):
         pt = self.read_particle_trajectory(pID)
-        vx, vy, vz = pt.get_vector("v")
-        bx, by, bz = pt.get_vector("b")
+        vx, vy, vz = pt["velocity"]
+        bx, by, bz = pt["b"]
 
         v_vec = np.vstack((vx, vy, vz)).T
         b_vec = np.vstack((bx, by, bz)).T
@@ -587,7 +555,7 @@ class FLEKSTP(object):
                 f, ax = plt.subplots(
                     2, 1, figsize=(10, 6), constrained_layout=True, sharex=True
                 )
-            y1, y2, y3 = pt.get_vector("x")
+            y1, y2, y3 = pt["position"]
 
             ax[0].set_xlabel("t")
             ax[0].set_ylabel("location")
@@ -596,7 +564,7 @@ class FLEKSTP(object):
             ax[0].plot(t, y2, label="y")
             ax[0].plot(t, y3, label="z")
 
-            y1, y2, y3 = pt.get_vector("v")
+            y1, y2, y3 = pt["velocity"]
 
             ax[1].plot(t, y1, label="vx")
             ax[1].plot(t, y2, label="vy")
@@ -657,15 +625,15 @@ class FLEKSTP(object):
 
             # --- Data Extraction ---
             t = pt.trajectory[:, Indices.TIME]  # [s]
-            x, y, z = pt.get_vector("x")  # [RE]
-            vx, vy, vz = pt.get_vector("v")  # [km/s]
-            bx, by, bz = pt.get_vector("b")  # [nT]
-            ex, ey, ez = pt.get_vector("e")  # [muV/m]
+            x, y, z = pt["position"]  # [RE]
+            vx, vy, vz = pt["velocity"]  # [km/s]
+            bx, by, bz = pt["b"]  # [nT]
+            ex, ey, ez = pt["e"]  # [muV/m]
 
             # --- Derived Quantities Calculation ---
 
             # Kinetic Energy
-            ke = self.get_kinetic_energy(vx, vy, vz) * 1e6 # [eV]
+            ke = self.get_kinetic_energy(vx, vy, vz) * 1e6  # [eV]
 
             # Vectorize B and V fields for easier calculations
             v_vec = np.vstack((vx, vy, vz)).T

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -108,9 +108,7 @@ class ParticleTrajectory:
                 f"Unknown key: '{key}'. Valid keys include {list(component_map.keys()) + list(vector_map.keys())}"
             )
 
-    def get_vector(
-        self, vector_type: str
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def get_vector(self, vector_type: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         """
         A generic function to get vector components from a ParticleTrajectory.
 
@@ -298,7 +296,6 @@ class FLEKSTP(object):
         Examples:
         >>> ids, pData = pt.read_particles_at_time(3700, doSave=True)
         """
-
         nFile = len(self.pfiles)
         if time < self.filetime[0]:
             raise Exception(f"There are no particles at time {time}.")
@@ -420,6 +417,7 @@ class FLEKSTP(object):
 
         nRecord = int(len(dataList) / self.nReal)
         trajectory_data = np.array(dataList).reshape(nRecord, self.nReal)
+
         return ParticleTrajectory(pID, trajectory_data)
 
     def read_initial_location(self, pID):
@@ -465,6 +463,7 @@ class FLEKSTP(object):
 
         return pSelected
 
+    @staticmethod
     def get_kinetic_energy(vx, vy, vz, mass=proton_mass):
         # Assume velocity in units of [m/s]
         ke = 0.5 * mass * (vx**2 + vy**2 + vz**2) / elementary_charge  # [eV]
@@ -633,9 +632,7 @@ class FLEKSTP(object):
                 a.set_xlabel("x" if i < 2 else "y")
                 a.set_ylabel("y" if i == 0 else "z")
 
-            plot_vector(
-                [Indices.X, Indices.Y, Indices.Z], ["x", "y", "z"], 1
-            )
+            plot_vector([Indices.X, Indices.Y, Indices.Z], ["x", "y", "z"], 1)
             plot_vector(
                 [Indices.VX, Indices.VY, Indices.VZ],
                 ["Vx", "Vy", "Vz"],
@@ -660,18 +657,15 @@ class FLEKSTP(object):
 
             # --- Data Extraction ---
             t = pt.trajectory[:, Indices.TIME]  # [s]
-            x, y, z = pt.get_vector("x") # [RE]
-            vx, vy, vz = pt.get_vector("v") # [km/s]
-            bx, by, bz = pt.get_vector("b") # [nT]
-            ex, ey, ez = pt.get_vector("e") # [muV/m]
+            x, y, z = pt.get_vector("x")  # [RE]
+            vx, vy, vz = pt.get_vector("v")  # [km/s]
+            bx, by, bz = pt.get_vector("b")  # [nT]
+            ex, ey, ez = pt.get_vector("e")  # [muV/m]
 
             # --- Derived Quantities Calculation ---
 
             # Kinetic Energy
-            # ke = tp.get_kinetic_energy(vx, vy, vz) * 1e6 # [eV]
-            ke = (
-                0.5 * proton_mass * (vx**2 + vy**2 + vz**2) * 1e6 / elementary_charge
-            )  # [eV]
+            ke = self.get_kinetic_energy(vx, vy, vz) * 1e6 # [eV]
 
             # Vectorize B and V fields for easier calculations
             v_vec = np.vstack((vx, vy, vz)).T
@@ -687,7 +681,7 @@ class FLEKSTP(object):
             U_B = (b_mag * 1e-9) ** 2 / (2 * mu_0)  # [J/m^3]
 
             # Electric Field Energy Density Calculation
-            U_E = 0.5 * epsilon_0 * (e_mag * 1e-3) ** 2  # [J/m^3]
+            U_E = 0.5 * epsilon_0 * (e_mag * 1e-6) ** 2  # [J/m^3]
 
             # Pitch Angle Calculation
             v_dot_b = np.sum(v_vec * b_vec, axis=1)

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -622,7 +622,7 @@ class FLEKSTP(object):
                 )
         elif type == "full":
             print(f"Analyzing particle ID: {pt.pid}")
-
+            #TODO Proper unit handling
             # --- Data Extraction ---
             t = pt.trajectory[:, Indices.TIME]  # [s]
             x, y, z = pt["position"]  # [RE]
@@ -643,13 +643,13 @@ class FLEKSTP(object):
             # Calculate magnitudes of vectors
             v_mag = np.linalg.norm(v_vec, axis=1)  # [km/s]
             b_mag = np.linalg.norm(b_vec, axis=1)  # [nT]
-            e_mag = np.linalg.norm(e_vec, axis=1)  # [muV/m]
+            e_mag = np.linalg.norm(e_vec, axis=1) * 1e-3  # [mV/m]
 
             # Magnetic Field Energy Density Calculation
             U_B = (b_mag * 1e-9) ** 2 / (2 * mu_0)  # [J/m^3]
 
             # Electric Field Energy Density Calculation
-            U_E = 0.5 * epsilon_0 * (e_mag * 1e-6) ** 2  # [J/m^3]
+            U_E = 0.5 * epsilon_0 * (e_mag * 1e-3) ** 2  # [J/m^3]
 
             # Pitch Angle Calculation
             v_dot_b = np.sum(v_vec * b_vec, axis=1)
@@ -713,7 +713,7 @@ class FLEKSTP(object):
             ax[5].plot(t, ex, label="$E_x$")
             ax[5].plot(t, ey, label="$E_y$")
             ax[5].plot(t, ez, label="$E_z$")
-            ax[5].set_ylabel(r"E [$mu$V/m]", fontsize=14)
+            ax[5].set_ylabel("E [mV/m]", fontsize=14)
 
             # Panel 6: Pitch Angle
             ax[6].plot(t, pitch_angle, color="tab:brown")
@@ -766,7 +766,7 @@ class FLEKSTP(object):
         py = pData[:, Indices.Y]
         pz = pData[:, Indices.Z]
 
-        # create subplot mosaic with different keyword arguments
+        # Create subplot mosaic with different keyword arguments
         skeys = ["A", "B", "C", "D"]
         f, ax = plt.subplot_mosaic(
             "AB;CD",

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -136,17 +136,18 @@ class TestParticles:
         pIDs = self.pIDs
         assert tp.__repr__().startswith("Particles")
         assert pIDs[0] == (0, 5121)
-        traj = tp.read_particle_trajectory(pIDs[10])
-        assert traj[0, 1] == -0.031386006623506546
-        assert tp.get_data(traj, "u")[3] == 5.870406312169507e-05
-        assert tp.get_data(traj, "v")[5] == 4.103916944586672e-05
-        assert tp.get_data(traj, "w").shape == (8,)
+        pt = tp.read_particle_trajectory(pIDs[10])
+        assert pt.trajectory[0, 1] == -0.031386006623506546
+        assert tp.get_data(pt, "u")[3] == 5.870406312169507e-05
+        assert tp.get_data(pt, "v")[5] == 4.103916944586672e-05
+        assert tp.get_data(pt, "w").shape == (8,)
+        assert tp.get_vector(pt, "x")[0].shape == (8,)
         assert tp.Indices.TIME == 0
         assert tp.Indices.BX == 7 and tp.Indices.EZ == 12
         with pytest.raises(Exception):
-            tp.get_data(traj, "unknown")
+            tp.get_data(pt, "unknown")
         x = tp.read_initial_location(pIDs[10])
-        assert x[1] == traj[0, 1]
+        assert x[1] == pt.trajectory[0, 1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
         assert ids[1][1] == 5129
         ax = tp.plot_location(pData[0:2, :])

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -141,7 +141,7 @@ class TestParticles:
         assert pt["u"][3] == 5.870406312169507e-05
         assert pt["v"][5] == 4.103916944586672e-05
         assert pt["w"].shape == (8,)
-        assert pt.get_vector("x")[0].shape == (8,)
+        assert pt["position"][0].shape == (8,)
         with pytest.raises(Exception):
             pt["unknown"]
         x = tp.read_initial_location(pIDs[10])

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -138,14 +138,12 @@ class TestParticles:
         assert pIDs[0] == (0, 5121)
         pt = tp.read_particle_trajectory(pIDs[10])
         assert pt.trajectory[0, 1] == -0.031386006623506546
-        assert tp.get_data(pt, "u")[3] == 5.870406312169507e-05
-        assert tp.get_data(pt, "v")[5] == 4.103916944586672e-05
-        assert tp.get_data(pt, "w").shape == (8,)
-        assert tp.get_vector(pt, "x")[0].shape == (8,)
-        assert tp.Indices.TIME == 0
-        assert tp.Indices.BX == 7 and tp.Indices.EZ == 12
+        assert pt["u"][3] == 5.870406312169507e-05
+        assert pt["v"][5] == 4.103916944586672e-05
+        assert pt["w"].shape == (8,)
+        assert pt.get_vector("x")[0].shape == (8,)
         with pytest.raises(Exception):
-            tp.get_data(pt, "unknown")
+            pt["unknown"]
         x = tp.read_initial_location(pIDs[10])
         assert x[1] == pt.trajectory[0, 1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
@@ -158,11 +156,11 @@ class TestParticles:
             ids, pData = tp.read_particles_at_time(10.0, doSave=False)
 
     def test_particle_select(self):
-        from flekspy import FLEKSTP
+        from flekspy.tp import Indices
 
         def f_select(tp, pid):
             pData = tp.read_initial_location(pid)
-            inRegion = pData[tp.Indices.X] > 0 and pData[tp.Indices.Y] > 0
+            inRegion = pData[Indices.X] > 0 and pData[Indices.Y] > 0
             return inRegion
 
         pSelected = self.tp.select_particles(f_select)


### PR DESCRIPTION
This PR refactors the internals of the test particle module. More specifically,

- Add a new ParticleTrajectory class to combine the particle ID and particle data together.
- Refactor `get_data` with `__getitem__`, for more native Python operations.
- Add utility methods for obtaining vectors directly, `get_kinetic_energy`, `get_pitch_angle`, `get_pitch_angle_from_v_b`, and `get_first_adiabatic_invariant`. This can be further improved later.
- Add a more thorough `type == "full"` trajectory plot.