### PR TITLE
Fix: evaluate_expression

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,14 +41,16 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run benchmark
+        if: github.event_name == 'pull_request'
         run: |
-          uv run pytest --benchmark-only --benchmark-json output.json
+          uv run pytest --benchmark-only > benchmark.txt
 
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'pytest'
-          output-file-path: output.json
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body-file benchmark.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build documentation
         run: uv run make html --directory docs/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,29 +40,6 @@ jobs:
           files: ./coverage.xml   # coverage report
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Run benchmark
-        if: github.event_name == 'pull_request'
-        run: |
-          uv run pytest --benchmark-only > benchmark.md
-
-      - name: Find comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
-        id: find
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: "Benchmark Results"
-
-      - name: Create or update comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.find.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: benchmark.md
-          edit-mode: replace
-
       - name: Build documentation
         run: uv run make html --directory docs/
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,14 +43,25 @@ jobs:
       - name: Run benchmark
         if: github.event_name == 'pull_request'
         run: |
-          uv run pytest --benchmark-only > benchmark.txt
+          uv run pytest --benchmark-only > benchmark.md
 
-      - name: Comment on PR
+      - name: Find comment
         if: github.event_name == 'pull_request'
-        run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body-file benchmark.txt
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: peter-evans/find-comment@v3
+        id: find
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "Benchmark Results"
+
+      - name: Create or update comment
+        if: github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: benchmark.md
+          edit-mode: replace
 
       - name: Build documentation
         run: uv run make html --directory docs/

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,43 @@
+name: benchmark
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'src/flekspy/idl/**'
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check-out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run benchmark
+        run: |
+          uv run pytest --benchmark-only > benchmark.md
+
+      - name: Find comment
+        uses: peter-evans/find-comment@v3
+        id: find
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: "Benchmark Results"
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: benchmark.md
+          edit-mode: replace

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,14 +17,16 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Set up Python
-        run: uv python install
+        run: |
+          uv python install
+          uv pip install pytest-md-report
 
       - name: Install the project
         run: uv sync --all-extras --dev
 
       - name: Run benchmark
         run: |
-          uv run pytest --benchmark-only > benchmark.md
+          uv run pytest --benchmark-only --md-report > benchmark.md
 
       - name: Find comment
         uses: peter-evans/find-comment@v3

--- a/docs/demo_amrex_output.ipynb
+++ b/docs/demo_amrex_output.ipynb
@@ -38,11 +38,9 @@
     "ds = flekspy.load(\"data/fleks_particle_small/3d*amrex\")\n",
     "dc = ds.get_slice(\"z\", 0.001)\n",
     "\n",
-    "f, axes = dc.plot(\n",
-    "    \"Bx<(1.5e4)>(-1.5e4) ({rhos0}+{rhos1})<(1.3e21) pS0 uxs0\", figsize=(12, 8)\n",
-    ")\n",
+    "f, axes = dc.plot(\"Bx>(2.2e5)<(3e5) Ex\", figsize=(12, 6))\n",
     "dc.add_stream(axes[0], \"Bx\", \"By\", color=\"w\")\n",
-    "dc.add_contour(axes[1], \"Bx\")"
+    "dc.add_contour(axes[1], \"Bx\", color=\"k\")"
    ]
   },
   {

--- a/src/flekspy/util/data_container.py
+++ b/src/flekspy/util/data_container.py
@@ -119,19 +119,28 @@ class DataContainer(object):
             expression (str): Python codes to be executed
             Example: expression = "np.log({rhos0}+{rhos1})"
         """
+        import re
 
-        if expression.find("{") < 0:
+        if '{' not in expression:
             return self.get_variable(expression, unit)
 
-        exp1 = expression.replace("{", "self.get_variable('")
+        # A dictionary to store the variables for eval.
+        eval_context = {'np': np}
 
-        exp2 = exp1.replace("}", "',unit)")
-        exp2 = r"result=" + exp2
+        def repl(match):
+            var_name = match.group(1)
+            # Add the variable to the context for eval.
+            # Use a name that is valid for a python identifier.
+            eval_context[var_name] = self.get_variable(var_name, unit)
+            return var_name
 
-        print(exp2)
-        exec(exp2)
+        # Replace `{var}` with `var` and populate `eval_context`.
+        expression_for_eval = re.sub(r'\{(.*?)\}', repl, expression)
 
-        return locals()["result"]
+        # Evaluate the expression in the prepared context.
+        # We allow access to numpy (np) and the variables in the expression.
+        # We provide an empty `__builtins__` to restrict access to other built-in functions for security.
+        return eval(expression_for_eval, {"__builtins__": {}, "np": np}, eval_context)
 
     def add_variable(self, name, val):
         r"""
@@ -161,6 +170,7 @@ class DataContainer(object):
         Return: YTArray
         """
 
+        ytarr = None
         if var in self.data.keys():
             varUnit = get_unit(var, unit)
             ytarr = self.data[var]
@@ -201,6 +211,9 @@ class DataContainer(object):
                 if type(ytarr) != yt.units.yt_array.YTArray:
                     varUnit = "dimensionless"
                     ytarr = yt.YTArray(ytarr, varUnit)
+
+        if ytarr is None:
+            raise KeyError(f"Variable '{var}' not found in dataset.")
 
         return ytarr if str(ytarr.units) == "dimensionless" else ytarr.in_units(varUnit)
 

--- a/src/flekspy/util/data_container.py
+++ b/src/flekspy/util/data_container.py
@@ -138,9 +138,8 @@ class DataContainer(object):
         expression_for_eval = re.sub(r'\{(.*?)\}', repl, expression)
 
         # Evaluate the expression in the prepared context.
-        # We allow access to numpy (np) and the variables in the expression.
         # We provide an empty `__builtins__` to restrict access to other built-in functions for security.
-        return eval(expression_for_eval, {"__builtins__": {}, "np": np}, eval_context)
+        return eval(expression_for_eval, {"__builtins__": {}}, eval_context)
 
     def add_variable(self, name, val):
         r"""

--- a/src/flekspy/util/utilities.py
+++ b/src/flekspy/util/utilities.py
@@ -152,7 +152,7 @@ def download_testfile(url: str, target_path="."):
         target_dir.mkdir(parents=True, exist_ok=True)
 
         with tarfile.open(temp_file, "r:gz") as tar:
-            tar.extractall(target_dir)
+            tar.extractall(target_dir, filter="data")
 
     except requests.exceptions.RequestException as e:
         print(f"Error downloading file: {e}")

--- a/tests/test_evaluate_expression.py
+++ b/tests/test_evaluate_expression.py
@@ -1,0 +1,47 @@
+import pytest
+import os
+import numpy as np
+
+import flekspy as fs
+from flekspy.util import download_testfile
+
+import matplotlib
+
+matplotlib.use("agg")
+
+
+filedir = os.path.dirname(__file__)
+
+if not os.path.isdir(filedir + "/data/3d_particle_region0_1_t00000002_n00000007_amrex"):
+    url = "https://raw.githubusercontent.com/henry2004y/batsrus_data/master/3d_particle.tar.gz"
+    download_testfile(url, "tests/data")
+
+
+class TestEvaluateExpression:
+    files = ("3d*amrex",)
+    files = [os.path.join("tests/data/", file) for file in files]
+
+    def test_evaluate_expression(self):
+        ds = fs.load(self.files[0])
+        dc = ds.get_slice("z", 0.5)
+
+        # Test a simple expression
+        result = dc.evaluate_expression("{Bx} + {By}")
+
+        import yt
+        assert isinstance(result, yt.units.yt_array.YTArray)
+        assert result.shape == dc.data["Bx"].shape
+        expected = dc.data["Bx"] + dc.data["By"]
+        np.testing.assert_allclose(result.value, expected.value)
+
+        # Test an expression with a function call
+        result = dc.evaluate_expression("np.sqrt({Bx}**2+{By}**2)")
+
+        assert isinstance(result, yt.units.yt_array.YTArray)
+        assert result.shape == dc.data["Bx"].shape
+        expected = np.sqrt(dc.data["Bx"]**2 + dc.data["By"]**2)
+        np.testing.assert_allclose(result.value, expected.value)
+
+        # Test with a non-existent variable
+        with pytest.raises(KeyError):
+            dc.evaluate_expression("{non_existent_var}")


### PR DESCRIPTION
I've fixed a runtime error and refactored the `evaluate_expression` function for you.

The `get_variable` function was raising an `UnboundLocalError` when a requested variable was not found in the dataset. I fixed this by initializing the local variable and raising a `KeyError` with a more informative message.

I also refactored the `evaluate_expression` function to use `eval` with a controlled environment instead of `exec`. This new implementation is safer and cleaner.

Finally, I added a new test to cover these changes