### PR TITLE
Refactor: Replace eval() with ast for safe expression evaluation


### DIFF
--- a/src/flekspy/util/data_container.py
+++ b/src/flekspy/util/data_container.py
@@ -8,6 +8,7 @@ from scipy.interpolate import griddata
 
 from flekspy.util.utilities import get_unit
 from flekspy.plot.streamplot import streamplot
+from flekspy.util.safe_eval import safe_eval
 
 
 def compare(d1, d2):
@@ -138,8 +139,7 @@ class DataContainer(object):
         expression_for_eval = re.sub(r"\{(.*?)\}", repl, expression)
 
         # Evaluate the expression in the prepared context.
-        # We provide an empty `__builtins__` to restrict access to other built-in functions for security.
-        return eval(expression_for_eval, {"__builtins__": {}}, eval_context)
+        return safe_eval(expression_for_eval, eval_context)
 
     def add_variable(self, name, val):
         r"""

--- a/src/flekspy/util/safe_eval.py
+++ b/src/flekspy/util/safe_eval.py
@@ -1,0 +1,93 @@
+import ast
+import operator as op
+
+import numpy as np
+
+
+class SafeExpressionEvaluator:
+    def __init__(self, context):
+        self.context = context
+        self._allowed_nodes = {
+            ast.Expression,
+            ast.BinOp,
+            ast.UnaryOp,
+            ast.Call,
+            ast.Name,
+            ast.Load,
+            ast.Constant,
+            ast.Attribute,
+        }
+        self._allowed_ops = {
+            ast.Add: op.add,
+            ast.Sub: op.sub,
+            ast.Mult: op.mul,
+            ast.Div: op.truediv,
+            ast.Pow: op.pow,
+            ast.USub: op.neg,
+        }
+        self._allowed_functions = {
+            "np": {
+                "sqrt": np.sqrt,
+                "log": np.log,
+                "log10": np.log10,
+                "abs": np.abs,
+            }
+        }
+
+    def _eval_node(self, node):
+        if not isinstance(node, ast.AST):
+            raise TypeError(f"Unsupported node type: {type(node)}")
+
+        node_type = type(node)
+        if node_type not in self._allowed_nodes:
+            raise ValueError(f"Unsupported node type: {node_type.__name__}")
+
+        if isinstance(node, ast.Expression):
+            return self._eval_node(node.body)
+        elif isinstance(node, ast.Constant):
+            return node.value
+        elif isinstance(node, ast.Name):
+            if node.id in self.context:
+                return self.context[node.id]
+            raise NameError(f"Name '{node.id}' is not defined in the context.")
+        elif isinstance(node, ast.BinOp):
+            left = self._eval_node(node.left)
+            right = self._eval_node(node.right)
+            op_type = type(node.op)
+            if op_type in self._allowed_ops:
+                return self._allowed_ops[op_type](left, right)
+            raise ValueError(f"Unsupported binary operator: {op_type.__name__}")
+        elif isinstance(node, ast.UnaryOp):
+            operand = self._eval_node(node.operand)
+            op_type = type(node.op)
+            if op_type in self._allowed_ops:
+                return self._allowed_ops[op_type](operand)
+            raise ValueError(f"Unsupported unary operator: {op_type.__name__}")
+        elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute) and isinstance(
+                node.func.value, ast.Name
+            ):
+                namespace = node.func.value.id
+                func_name = node.func.attr
+                if (
+                    namespace in self._allowed_functions
+                    and func_name in self._allowed_functions[namespace]
+                ):
+                    args = [self._eval_node(arg) for arg in node.args]
+                    return self._allowed_functions[namespace][func_name](*args)
+            raise NameError(
+                f"Unsupported function call: {ast.dump(node.func)}"
+            )
+        else:
+            raise TypeError(f"Unsupported node type: {node_type.__name__}")
+
+    def eval(self, expression):
+        try:
+            node = ast.parse(expression, mode="eval")
+            return self._eval_node(node)
+        except (ValueError, TypeError, NameError, SyntaxError) as e:
+            raise type(e)(f"Failed to evaluate expression: {e}") from e
+
+
+def safe_eval(expression, context):
+    return SafeExpressionEvaluator(context).eval(expression)


### PR DESCRIPTION
The use of `eval()` on strings you provide is a security
vulnerability, as it can be used to execute arbitrary code.

This commit refactors the `evaluate_expression` method in
`flekspy.util.data_container` to use a safer implementation based on
Python's `ast` module.

A new `safe_eval` function is introduced in `flekspy.util.safe_eval`,
which parses the expression into an Abstract Syntax Tree (AST) and
validates it against a whitelist of allowed nodes and functions.
This prevents the execution of arbitrary code and mitigates the
security risk.