### PR TITLE
Refactor IDLData to use xarray

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,12 @@ dependencies = [
     "matplotlib>=3.8.2,<4",
     "scipy>=1.14.1,<2",
     "requests>=2.32.3,<3",
+    "xarray>=2024.6.0",
+    "netcdf4>=1.6.5",
+    "h5netcdf>=1.3.0",
 ]
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "pytest>=8.0.0,<9",
     "pytest-benchmark>=4.0.0,<5",

--- a/src/flekspy/__init__.py
+++ b/src/flekspy/__init__.py
@@ -5,7 +5,7 @@ flekspy Public API.
 from pathlib import Path
 import errno
 from itertools import islice
-from flekspy.idl import IDLData
+from flekspy.idl.idl import IDLDataX
 from flekspy.yt import FLEKSData, extract_phase
 from flekspy.tp import FLEKSTP
 
@@ -52,7 +52,7 @@ def load(
     if basename == "test_particles":
         return FLEKSTP(filename, iDomain=iDomain, iSpecies=iSpecies)
     elif filepath.suffix in [".out", ".outs"]:
-        return IDLData(filename)
+        return IDLDataX(filename)
     elif basename.endswith("_amrex"):
         return FLEKSData(filename, readFieldData)
     else:


### PR DESCRIPTION
This commit refactors the `IDLData` class to use `xarray.Dataset` as the underlying data structure. A new class, `IDLDataX`, is introduced to handle the `xarray`-based data, and the `flekspy.load` function has been updated to use this new class for IDL files.

The main changes include:
- A new `IDLDataX` class that inherits from `IDLData` and uses an `xarray.Dataset` to store the data.
- Overridden methods in `IDLDataX` (`get_domain`, `get_slice`, `plot`, `pcolormesh`, `extract_data`, `get_data`) to leverage `xarray`'s capabilities.
- Updated tests to validate the new `xarray`-based implementation.
- Added `xarray` as a dependency in `pyproject.toml`.