### PR TITLE
Refactor test particle with pandas support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "scipy>=1.14.1,<2",
     "requests>=2.32.3,<3",
     "xarray>=2024.6.0",
+    "pandas>=2.3.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/src/flekspy/tp/__init__.py
+++ b/src/flekspy/tp/__init__.py
@@ -1,1 +1,1 @@
-from .test_particles import FLEKSTP, Indices, ParticleTrajectory
+from .test_particles import FLEKSTP, Indices

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -9,7 +9,7 @@ import glob
 import struct
 from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
-
+import pandas as pd
 
 class Indices(IntEnum):
     """Defines constant indices for test particles."""
@@ -335,34 +335,22 @@ class FLEKSTP(object):
                             binaryData = f.read(4 * self.nReal)
                             return list(struct.unpack("f" * self.nReal, binaryData))
 
-    def read_particle_trajectory(self, pID: Tuple[int, int]) -> DataFrame:
+    def read_particle_trajectory(self, pID: Tuple[int, int]) -> pd.DataFrame:
         """
-        Return the trajectory of a test particle.
-
-        Args:
-            pID: particle ID
-
-        Examples:
-        >>> trajectory = tp.read_particle_trajectory((66,888))
+        Return the trajectory of a test particle as a pandas DataFrame.
         """
         dataList = self._get_particle_raw_data(pID)
 
         if not dataList:
-            # Return an empty trajectory if no data is found
-            return pd.DataFrame()
+            return pd.DataFrame() # Return an empty DataFrame if no data
 
         nRecord = int(len(dataList) / self.nReal)
         trajectory_data = np.array(dataList).reshape(nRecord, self.nReal)
 
-        # Create a list of column names from the Indices enum
-        column_names = [
-            name.lower() for name, member in Indices.__members__.items()
-        ]
+        # Use the Indices enum to create meaningful column names
+        column_names = [i.name.lower() for i in Indices]
 
-        # Create a DataFrame
-        df = pd.DataFrame(trajectory_data, columns=column_names[: self.nReal])
-        df.attrs["pid"] = pID
-        return df
+        return pd.DataFrame(trajectory_data, columns=column_names)
 
     def read_initial_condition(self, pID: Tuple[int, int]) -> Union[list, None]:
         """

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -353,7 +353,9 @@ class FLEKSTP(object):
         # Use the Indices enum to create meaningful column names
         column_names = [i.name.lower() for i in Indices]
 
-        return pd.DataFrame(trajectory_data, columns=column_names)
+        df = pd.DataFrame(trajectory_data, columns=column_names[: self.nReal])
+        df.attrs["pid"] = pID
+        return df
 
     def read_initial_condition(self, pID: Tuple[int, int]) -> Union[list, None]:
         """

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -11,6 +11,7 @@ from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
 import pandas as pd
 
+
 class Indices(IntEnum):
     """Defines constant indices for test particles."""
 
@@ -289,7 +290,9 @@ class FLEKSTP(object):
                         )
         return dataList
 
-    def _read_particle_record(self, pID: Tuple[int, int], index: int = -1) -> Union[list, None]:
+    def _read_particle_record(
+        self, pID: Tuple[int, int], index: int = -1
+    ) -> Union[list, None]:
         """
         Return a specific record of a test particle given its ID.
 
@@ -342,7 +345,7 @@ class FLEKSTP(object):
         dataList = self._get_particle_raw_data(pID)
 
         if not dataList:
-            return pd.DataFrame() # Return an empty DataFrame if no data
+            return pd.DataFrame()  # Return an empty DataFrame if no data
 
         nRecord = int(len(dataList) / self.nReal)
         trajectory_data = np.array(dataList).reshape(nRecord, self.nReal)

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -195,7 +195,7 @@ def load(files):
     return ds
 
 
-def test_load(benchmark):
+def test_load_idl(benchmark):
     filenames = (
         "1d__raw_2_t25.60000_n00000258.out",
         "z=0_fluid_region0_0_t00001640_n00010142.out",
@@ -207,7 +207,7 @@ def test_load(benchmark):
     assert isinstance(result, xr.Dataset)
 
 
-def load_all_trajectories(tp, pIDs):
+def load_test_particle_trajectories(tp, pIDs):
     """
     Load all particle trajectories.
     """
@@ -215,7 +215,7 @@ def load_all_trajectories(tp, pIDs):
         tp.read_particle_trajectory(pID)
 
 
-def test_load_all_trajectories(benchmark):
+def test_load_tp(benchmark):
     """
     Benchmark loading all particle trajectories.
     """
@@ -225,4 +225,4 @@ def test_load_all_trajectories(benchmark):
     tp = FLEKSTP(dirs, iSpecies=1)
     pIDs = tp.getIDs()
 
-    benchmark(load_all_trajectories, tp, pIDs)
+    benchmark(load_test_particle_trajectories, tp, pIDs)

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -143,17 +143,16 @@ class TestParticles:
         assert tp.__repr__().startswith("Particles")
         assert pIDs[0] == (0, 5121)
         pt = tp.read_particle_trajectory(pIDs[10])
-        assert pt.trajectory[0, 1] == -0.031386006623506546
-        assert pt["u"][3] == 5.870406312169507e-05
-        assert pt["v"][5] == 4.103916944586672e-05
-        assert pt["w"].shape == (8,)
-        assert pt["position"][0].shape == (8,)
+        assert pt["x"].iloc[0] == -0.031386006623506546
+        assert pt["vx"].iloc[3] == 5.870406312169507e-05
+        assert pt["vy"].iloc[5] == 4.103916944586672e-05
+        assert pt["vz"].shape == (8,)
         with pytest.raises(Exception):
             pt["unknown"]
         x = tp.read_initial_condition(pIDs[10])
-        assert x[1] == pt.trajectory[0, 1]
+        assert x[1] == pt["x"].iloc[0]
         x = tp.read_final_condition(pIDs[10])
-        assert x[1] == pt.trajectory[-1, 1]
+        assert x[1] == pt["x"].iloc[-1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
         assert ids[1][1] == 5129
         ax = tp.plot_location(pData[0:2, :])


### PR DESCRIPTION
Refactor: Replace ParticleTrajectory with pandas DataFrame

- Replaced the `ParticleTrajectory` class with a pandas DataFrame to store test particle trajectory data.
- Updated `read_particle_trajectory` to return a DataFrame.
- Modified related methods (`save_trajectory_to_csv`, `get_first_adiabatic_invariant`, `get_pitch_angle`, `plot_trajectory`) to work with the new DataFrame structure.
- Updated tests to reflect the changes.