### PR TITLE
Refactor test particles with polars support

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -606,10 +606,7 @@
    "outputs": [],
    "source": [
     "traj = tp.read_particle_trajectory(pIDs[10])\n",
-    "print(\"time:\\n\")\n",
-    "print(traj[\"t\"])\n",
-    "print(\"x:\\n\")\n",
-    "print(traj[\"x\"])"
+    "traj"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "scipy>=1.14.1,<2",
     "requests>=2.32.3,<3",
     "xarray>=2024.6.0",
+    "pandas>=2.3.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "scipy>=1.14.1,<2",
     "requests>=2.32.3,<3",
     "xarray>=2024.6.0",
-    "pandas>=2.3.0,<3",
+    "polars>=0.20.21,<1",
 ]
 
 [project.optional-dependencies]

--- a/src/flekspy/tp/__init__.py
+++ b/src/flekspy/tp/__init__.py
@@ -1,1 +1,1 @@
-from .test_particles import FLEKSTP, Indices, ParticleTrajectory
+from .test_particles import FLEKSTP, Indices

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -4,12 +4,10 @@ import matplotlib.pyplot as plt
 from pathlib import Path
 import numpy as np
 import pandas as pd
-from pandas import DataFrame
 import glob
 import struct
 from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
-import pandas as pd
 
 
 class Indices(IntEnum):
@@ -267,7 +265,7 @@ class FLEKSTP(object):
             pData["time"] -= pData["time"].iloc[0]
             if scaleTime:
                 pData["time"] /= pData["time"].iloc[-1]
-        pData.to_csv(filename, header=header.split(","), index=False)
+        pData.to_csv(filename, header=header.split(', '), index=False)
 
     def _get_particle_raw_data(self, pID: Tuple[int, int]) -> list:
         """Reads all raw trajectory data for a particle across multiple files."""
@@ -464,7 +462,6 @@ class FLEKSTP(object):
 
         v_perp_sq = v_mag * v_mag * sin_alpha_sq
 
-        epsilon = 1e-15  # Avoid division by zero
         mu = (0.5 * mass * v_perp_sq) / (b_mag + epsilon)  # [J/nT]
 
         return mu
@@ -485,14 +482,6 @@ class FLEKSTP(object):
         Example:
         >>> tp.plot_trajectory((3,15))
         """
-
-        def plot_data(dd, label, irow, icol):
-            ax[irow, icol].plot(t, dd, label=label)
-            ax[irow, icol].scatter(
-                t, dd, c=plt.cm.winter(tNorm), edgecolor="none", marker="o", s=10
-            )
-            ax[irow, icol].set_xlabel("time")
-            ax[irow, icol].set_ylabel(label)
 
         def plot_data(dd, label, irow, icol):
             ax[irow, icol].plot(t, dd, label=label)

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -9,7 +9,7 @@ import glob
 import struct
 from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
-
+import pandas as pd
 
 class Indices(IntEnum):
     """Defines constant indices for test particles."""
@@ -335,34 +335,22 @@ class FLEKSTP(object):
                             binaryData = f.read(4 * self.nReal)
                             return list(struct.unpack("f" * self.nReal, binaryData))
 
-    def read_particle_trajectory(self, pID: Tuple[int, int]) -> DataFrame:
+    def read_particle_trajectory(self, pID: Tuple[int, int]) -> pd.DataFrame:
         """
-        Return the trajectory of a test particle.
-
-        Args:
-            pID: particle ID
-
-        Examples:
-        >>> trajectory = tp.read_particle_trajectory((66,888))
+        Return the trajectory of a test particle as a pandas DataFrame.
         """
         dataList = self._get_particle_raw_data(pID)
 
         if not dataList:
-            # Return an empty trajectory if no data is found
-            return pd.DataFrame()
+            return pd.DataFrame() # Return an empty DataFrame if no data
 
         nRecord = int(len(dataList) / self.nReal)
         trajectory_data = np.array(dataList).reshape(nRecord, self.nReal)
 
-        # Create a list of column names from the Indices enum
-        column_names = [
-            name.lower() for name, member in Indices.__members__.items()
-        ]
+        # Use the Indices enum to create meaningful column names
+        column_names = [i.name.lower() for i in Indices]
 
-        # Create a DataFrame
-        df = pd.DataFrame(trajectory_data, columns=column_names[: self.nReal])
-        df.attrs["pid"] = pID
-        return df
+        return pd.DataFrame(trajectory_data, columns=column_names)
 
     def read_initial_condition(self, pID: Tuple[int, int]) -> Union[list, None]:
         """

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -353,7 +353,9 @@ class FLEKSTP(object):
         # Use the Indices enum to create meaningful column names
         column_names = [i.name.lower() for i in Indices]
 
-        return pd.DataFrame(trajectory_data, columns=column_names)
+        df = pd.DataFrame(trajectory_data, columns=column_names[: self.nReal])
+        df.attrs["pid"] = pID
+        return df
 
     def read_initial_condition(self, pID: Tuple[int, int]) -> Union[list, None]:
         """

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -726,7 +726,7 @@ class FLEKSTP(object):
                 a.grid(True, which="both", linestyle="--", linewidth=0.5)
                 a.set_xlim(left=t.min(), right=t.max())
 
-            f.suptitle(f"Test Particle ID: {pt.attrs['pid']}", fontsize=16)
+            f.suptitle(f"Test Particle ID: {pID}", fontsize=16)
 
         return ax
 

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -11,6 +11,7 @@ from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
 import pandas as pd
 
+
 class Indices(IntEnum):
     """Defines constant indices for test particles."""
 
@@ -289,7 +290,9 @@ class FLEKSTP(object):
                         )
         return dataList
 
-    def _read_particle_record(self, pID: Tuple[int, int], index: int = -1) -> Union[list, None]:
+    def _read_particle_record(
+        self, pID: Tuple[int, int], index: int = -1
+    ) -> Union[list, None]:
         """
         Return a specific record of a test particle given its ID.
 
@@ -342,7 +345,7 @@ class FLEKSTP(object):
         dataList = self._get_particle_raw_data(pID)
 
         if not dataList:
-            return pd.DataFrame() # Return an empty DataFrame if no data
+            return pd.DataFrame()  # Return an empty DataFrame if no data
 
         nRecord = int(len(dataList) / self.nReal)
         trajectory_data = np.array(dataList).reshape(nRecord, self.nReal)

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -195,7 +195,7 @@ def load(files):
     return ds
 
 
-def test_load(benchmark):
+def test_load_idl(benchmark):
     filenames = (
         "1d__raw_2_t25.60000_n00000258.out",
         "z=0_fluid_region0_0_t00001640_n00010142.out",
@@ -207,7 +207,7 @@ def test_load(benchmark):
     assert isinstance(result, xr.Dataset)
 
 
-def load_all_trajectories(tp, pIDs):
+def load_test_particle_trajectories(tp, pIDs):
     """
     Load all particle trajectories.
     """
@@ -215,7 +215,7 @@ def load_all_trajectories(tp, pIDs):
         tp.read_particle_trajectory(pID)
 
 
-def test_load_all_trajectories(benchmark):
+def test_load_tp(benchmark):
     """
     Benchmark loading all particle trajectories.
     """
@@ -225,4 +225,4 @@ def test_load_all_trajectories(benchmark):
     tp = FLEKSTP(dirs, iSpecies=1)
     pIDs = tp.getIDs()
 
-    benchmark(load_all_trajectories, tp, pIDs)
+    benchmark(load_test_particle_trajectories, tp, pIDs)

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -211,7 +211,7 @@ def load_test_particle_trajectories(tp, pIDs):
     """
     Load all particle trajectories.
     """
-    for pID in itertools.islice(pIDs, 10):
+    for pID in itertools.islice(pIDs, 100):
         tp.read_particle_trajectory(pID)
 
 

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -143,16 +143,16 @@ class TestParticles:
         assert tp.__repr__().startswith("Particles")
         assert pIDs[0] == (0, 5121)
         pt = tp.read_particle_trajectory(pIDs[10])
-        assert pt["x"].iloc[0] == -0.031386006623506546
-        assert pt["vx"].iloc[3] == 5.870406312169507e-05
-        assert pt["vy"].iloc[5] == 4.103916944586672e-05
+        assert pt["x"][0] == -0.031386006623506546
+        assert pt["vx"][3] == 5.870406312169507e-05
+        assert pt["vy"][5] == 4.103916944586672e-05
         assert pt["vz"].shape == (8,)
         with pytest.raises(Exception):
             pt["unknown"]
         x = tp.read_initial_condition(pIDs[10])
-        assert x[1] == pt["x"].iloc[0]
+        assert x[1] == pt["x"][0]
         x = tp.read_final_condition(pIDs[10])
-        assert x[1] == pt["x"].iloc[-1]
+        assert x[1] == pt["x"][-1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
         assert ids[1][1] == 5129
         ax = tp.plot_location(pData[0:2, :])

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -143,17 +143,16 @@ class TestParticles:
         assert tp.__repr__().startswith("Particles")
         assert pIDs[0] == (0, 5121)
         pt = tp.read_particle_trajectory(pIDs[10])
-        assert pt.trajectory[0, 1] == -0.031386006623506546
-        assert pt["u"][3] == 5.870406312169507e-05
-        assert pt["v"][5] == 4.103916944586672e-05
-        assert pt["w"].shape == (8,)
-        assert pt["position"][0].shape == (8,)
+        assert pt["x"].iloc[0] == -0.031386006623506546
+        assert pt["vx"].iloc[3] == 5.870406312169507e-05
+        assert pt["vy"].iloc[5] == 4.103916944586672e-05
+        assert pt["vz"].shape == (8,)
         with pytest.raises(Exception):
             pt["unknown"]
         x = tp.read_initial_condition(pIDs[10])
-        assert x[1] == pt.trajectory[0, 1]
+        assert x[1] == pt["x"].iloc[0]
         x = tp.read_final_condition(pIDs[10])
-        assert x[1] == pt.trajectory[-1, 1]
+        assert x[1] == pt["x"].iloc[-1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
         assert ids[1][1] == 5129
         ax = tp.plot_location(pData[0:2, :])


### PR DESCRIPTION
Refactor: Replace ParticleTrajectory with polars DataFrame

- Replaced the ParticleTrajectory class with a pandas DataFrame to store test particle trajectory data.
- Updated read_particle_trajectory to return a DataFrame.
- Modified related methods (save_trajectory_to_csv, get_first_adiabatic_invariant, get_pitch_angle, plot_trajectory) to work with the new DataFrame structure.
- Updated tests to reflect the changes.

Built on top of #54. It seems that Polars is indeed faster than Pandas. 683 us vs 866 us. Original numpy implementation uses 243 us.