### PR TITLE
Refactor: Replace ParticleTrajectory with polars DataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 
 - `read_initial_location` -> `read_initial_condition` for test particles.
 
-## v0.3.3 (2025/08/03)
+## v0.4.0 (2025/08/03)
 
 - Use XArray for handling IDL format data.
+
+## v0.5.0 (2025/08/05)
+
+- Use Polars for storing test particle data.

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -606,10 +606,7 @@
    "outputs": [],
    "source": [
     "traj = tp.read_particle_trajectory(pIDs[10])\n",
-    "print(\"time:\\n\")\n",
-    "print(traj[\"t\"])\n",
-    "print(\"x:\\n\")\n",
-    "print(traj[\"x\"])"
+    "traj"
    ]
   },
   {

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -605,7 +605,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "traj = tp.read_particle_trajectory(pIDs[10])\n",
+    "traj = tp[10]\n",
     "traj"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flekspy"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python utilities for processing FLEKS data"
 authors = [
     {name = "Yuxi Chen", email = "yuxichen@umich.edu"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "scipy>=1.14.1,<2",
     "requests>=2.32.3,<3",
     "xarray>=2024.6.0",
+    "pandas>=2.3.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "scipy>=1.14.1,<2",
     "requests>=2.32.3,<3",
     "xarray>=2024.6.0",
-    "pandas>=2.3.0,<3",
+    "polars>=0.20.21,<1",
 ]
 
 [project.optional-dependencies]

--- a/src/flekspy/tp/__init__.py
+++ b/src/flekspy/tp/__init__.py
@@ -1,1 +1,1 @@
-from .test_particles import FLEKSTP, Indices, ParticleTrajectory
+from .test_particles import FLEKSTP, Indices

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -4,12 +4,10 @@ import matplotlib.pyplot as plt
 from pathlib import Path
 import numpy as np
 import pandas as pd
-from pandas import DataFrame
 import glob
 import struct
 from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
-import pandas as pd
 
 
 class Indices(IntEnum):
@@ -267,7 +265,7 @@ class FLEKSTP(object):
             pData["time"] -= pData["time"].iloc[0]
             if scaleTime:
                 pData["time"] /= pData["time"].iloc[-1]
-        pData.to_csv(filename, header=header.split(","), index=False)
+        pData.to_csv(filename, header=header.split(', '), index=False)
 
     def _get_particle_raw_data(self, pID: Tuple[int, int]) -> list:
         """Reads all raw trajectory data for a particle across multiple files."""
@@ -464,7 +462,6 @@ class FLEKSTP(object):
 
         v_perp_sq = v_mag * v_mag * sin_alpha_sq
 
-        epsilon = 1e-15  # Avoid division by zero
         mu = (0.5 * mass * v_perp_sq) / (b_mag + epsilon)  # [J/nT]
 
         return mu
@@ -485,14 +482,6 @@ class FLEKSTP(object):
         Example:
         >>> tp.plot_trajectory((3,15))
         """
-
-        def plot_data(dd, label, irow, icol):
-            ax[irow, icol].plot(t, dd, label=label)
-            ax[irow, icol].scatter(
-                t, dd, c=plt.cm.winter(tNorm), edgecolor="none", marker="o", s=10
-            )
-            ax[irow, icol].set_xlabel("time")
-            ax[irow, icol].set_ylabel(label)
 
         def plot_data(dd, label, irow, icol):
             ax[irow, icol].plot(t, dd, label=label)

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -34,6 +34,7 @@ class FLEKSTP(object):
     A class that is used to read and plot test particles. Each particle ID consists of
     a CPU index, a particle index on each CPU, and a location index.
     By default, 7 real numbers saved for each step: time + position + velocity.
+    Additional field information are also stored if available.
 
     This class is a lazy, iterable container. It avoids loading all data into memory
     at once, making it efficient for large datasets. You can access particle
@@ -46,10 +47,9 @@ class FLEKSTP(object):
     >>> tp = FLEKSTP("res/run1/PC/test_particles", iSpecies=1)
     >>> len(tp)
     10240
-    >>> pIDs = list(tp)
-    >>> trajectory = tp[pIDs[0]]
-    >>> tp.plot_trajectory(pIDs[3])
-    >>> tp.save_trajectory_to_csv(pIDs[5])
+    >>> trajectory = tp[0]
+    >>> tp.plot_trajectory(tp.IDs[3])
+    >>> tp.save_trajectory_to_csv(tp.IDs[5])
     >>> ids, pData = tp.read_particles_at_time(0.0, doSave=False)
     >>> f = tp.plot_location(pData)
     """

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -112,7 +112,7 @@ class FLEKSTP(object):
                     self.particle_locations[pID] = []
                 self.particle_locations[pID].append((p_filename, ploc))
 
-        self.IDs = self.particle_locations.keys()
+        self.IDs = sorted(self.particle_locations.keys())
 
         self.filetime = []
         for filename in self.pfiles:
@@ -140,7 +140,7 @@ class FLEKSTP(object):
         return self.read_particle_trajectory(pID)
 
     def getIDs(self):
-        return list(sorted(self.IDs))
+        return self.IDs
 
     def read_particle_list(self, filename: str) -> Dict[Tuple[int, int], int]:
         """
@@ -393,7 +393,7 @@ class FLEKSTP(object):
 
         # Use the Indices enum to create meaningful column names
         column_names = [i.name.lower() for i in islice(Indices, self.nReal)]
-        df = pl.DataFrame(data=trajectory_data, schema=column_names)
+        df = pl.from_numpy(data=trajectory_data, schema=column_names)
         return df
 
     def read_initial_condition(self, pID: Tuple[int, int]) -> Union[list, None]:

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -9,7 +9,7 @@ import glob
 import struct
 from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
-
+import pandas as pd
 
 class Indices(IntEnum):
     """Defines constant indices for test particles."""
@@ -335,34 +335,22 @@ class FLEKSTP(object):
                             binaryData = f.read(4 * self.nReal)
                             return list(struct.unpack("f" * self.nReal, binaryData))
 
-    def read_particle_trajectory(self, pID: Tuple[int, int]) -> DataFrame:
+    def read_particle_trajectory(self, pID: Tuple[int, int]) -> pd.DataFrame:
         """
-        Return the trajectory of a test particle.
-
-        Args:
-            pID: particle ID
-
-        Examples:
-        >>> trajectory = tp.read_particle_trajectory((66,888))
+        Return the trajectory of a test particle as a pandas DataFrame.
         """
         dataList = self._get_particle_raw_data(pID)
 
         if not dataList:
-            # Return an empty trajectory if no data is found
-            return pd.DataFrame()
+            return pd.DataFrame() # Return an empty DataFrame if no data
 
         nRecord = int(len(dataList) / self.nReal)
         trajectory_data = np.array(dataList).reshape(nRecord, self.nReal)
 
-        # Create a list of column names from the Indices enum
-        column_names = [
-            name.lower() for name, member in Indices.__members__.items()
-        ]
+        # Use the Indices enum to create meaningful column names
+        column_names = [i.name.lower() for i in Indices]
 
-        # Create a DataFrame
-        df = pd.DataFrame(trajectory_data, columns=column_names[: self.nReal])
-        df.attrs["pid"] = pID
-        return df
+        return pd.DataFrame(trajectory_data, columns=column_names)
 
     def read_initial_condition(self, pID: Tuple[int, int]) -> Union[list, None]:
         """

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -353,7 +353,9 @@ class FLEKSTP(object):
         # Use the Indices enum to create meaningful column names
         column_names = [i.name.lower() for i in Indices]
 
-        return pd.DataFrame(trajectory_data, columns=column_names)
+        df = pd.DataFrame(trajectory_data, columns=column_names[: self.nReal])
+        df.attrs["pid"] = pID
+        return df
 
     def read_initial_condition(self, pID: Tuple[int, int]) -> Union[list, None]:
         """

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -726,7 +726,7 @@ class FLEKSTP(object):
                 a.grid(True, which="both", linestyle="--", linewidth=0.5)
                 a.set_xlim(left=t.min(), right=t.max())
 
-            f.suptitle(f"Test Particle ID: {pt.attrs['pid']}", fontsize=16)
+            f.suptitle(f"Test Particle ID: {pID}", fontsize=16)
 
         return ax
 

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -11,6 +11,7 @@ from enum import IntEnum
 from scipy.constants import proton_mass, elementary_charge, mu_0, epsilon_0
 import pandas as pd
 
+
 class Indices(IntEnum):
     """Defines constant indices for test particles."""
 
@@ -289,7 +290,9 @@ class FLEKSTP(object):
                         )
         return dataList
 
-    def _read_particle_record(self, pID: Tuple[int, int], index: int = -1) -> Union[list, None]:
+    def _read_particle_record(
+        self, pID: Tuple[int, int], index: int = -1
+    ) -> Union[list, None]:
         """
         Return a specific record of a test particle given its ID.
 
@@ -342,7 +345,7 @@ class FLEKSTP(object):
         dataList = self._get_particle_raw_data(pID)
 
         if not dataList:
-            return pd.DataFrame() # Return an empty DataFrame if no data
+            return pd.DataFrame()  # Return an empty DataFrame if no data
 
         nRecord = int(len(dataList) / self.nReal)
         trajectory_data = np.array(dataList).reshape(nRecord, self.nReal)

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -103,9 +103,7 @@ class FLEKSTP(object):
         self.plistfiles = self.plistfiles[iListStart:iListEnd]
         self.pfiles = self.pfiles[iListStart:iListEnd]
 
-        self.particle_locations: Dict[
-            Tuple[int, int], List[Tuple[str, int]]
-        ] = {}
+        self.particle_locations: Dict[Tuple[int, int], List[Tuple[str, int]]] = {}
         for plist_filename, p_filename in zip(self.plistfiles, self.pfiles):
             plist = self.read_particle_list(plist_filename)
             for pID, ploc in plist.items():

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -195,7 +195,7 @@ def load(files):
     return ds
 
 
-def test_load(benchmark):
+def test_load_idl(benchmark):
     filenames = (
         "1d__raw_2_t25.60000_n00000258.out",
         "z=0_fluid_region0_0_t00001640_n00010142.out",
@@ -207,7 +207,7 @@ def test_load(benchmark):
     assert isinstance(result, xr.Dataset)
 
 
-def load_all_trajectories(tp, pIDs):
+def load_test_particle_trajectories(tp, pIDs):
     """
     Load all particle trajectories.
     """
@@ -215,7 +215,7 @@ def load_all_trajectories(tp, pIDs):
         tp.read_particle_trajectory(pID)
 
 
-def test_load_all_trajectories(benchmark):
+def test_load_tp(benchmark):
     """
     Benchmark loading all particle trajectories.
     """
@@ -225,4 +225,4 @@ def test_load_all_trajectories(benchmark):
     tp = FLEKSTP(dirs, iSpecies=1)
     pIDs = tp.getIDs()
 
-    benchmark(load_all_trajectories, tp, pIDs)
+    benchmark(load_test_particle_trajectories, tp, pIDs)

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -211,7 +211,7 @@ def load_test_particle_trajectories(tp, pIDs):
     """
     Load all particle trajectories.
     """
-    for pID in itertools.islice(pIDs, 10):
+    for pID in itertools.islice(pIDs, 100):
         tp.read_particle_trajectory(pID)
 
 

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -135,14 +135,13 @@ class TestParticles:
     from flekspy import FLEKSTP
 
     tp = FLEKSTP(dirs, iSpecies=1)
-    pIDs = tp.getIDs()
 
     def test_particles(self):
         tp = self.tp
-        pIDs = self.pIDs
+        pIDs = tp.getIDs()
         assert tp.__repr__().startswith("Particles")
         assert pIDs[0] == (0, 5121)
-        pt = tp.read_particle_trajectory(pIDs[10])
+        pt = tp[10]
         assert pt["x"][0] == -0.031386006623506546
         assert pt["vx"][3] == 5.870406312169507e-05
         assert pt["vy"][5] == 4.103916944586672e-05
@@ -151,7 +150,7 @@ class TestParticles:
             pt["unknown"]
         x = tp.read_initial_condition(pIDs[10])
         assert x[1] == pt["x"][0]
-        x = tp.read_final_condition(pIDs[10])
+        x = tp.read_final_condition(tp.IDs[10])
         assert x[1] == pt["x"][-1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
         assert ids[1][1] == 5129
@@ -175,7 +174,7 @@ class TestParticles:
 
     def test_trajectory(self):
         tp = self.tp
-        pIDs = self.pIDs
+        pIDs = tp.getIDs()
         ax = tp.plot_trajectory(pIDs[0], type="single")
         assert ax.get_xlim()[1] == 2.140599811077118
         ax = tp.plot_trajectory(pIDs[0], type="single", xaxis="y", yaxis="z", ax=ax)
@@ -192,22 +191,18 @@ class TestParticles:
     def test_read_particle_trajectory_value_error(self, monkeypatch):
         import numpy as np
 
-        pID = self.pIDs[0]
+        pID = self.tp.IDs[0]
         # Ensure the cache is clean for this test
         if pID in self.tp._trajectory_cache:
             del self.tp._trajectory_cache[pID]
 
         monkeypatch.setattr(
-            self.tp, "_get_particle_raw_data", lambda pID: np.array([], dtype=np.float32)
+            self.tp,
+            "_get_particle_raw_data",
+            lambda pID: np.array([], dtype=np.float32),
         )
         with pytest.raises(ValueError):
             self.tp.read_particle_trajectory(pID)
-
-    def test_getitem_with_int(self):
-        pID = self.pIDs[10]
-        traj_by_id = self.tp[pID]
-        traj_by_index = self.tp[10]
-        assert traj_by_id.equals(traj_by_index)
 
 
 def load(files):

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -143,16 +143,16 @@ class TestParticles:
         assert tp.__repr__().startswith("Particles")
         assert pIDs[0] == (0, 5121)
         pt = tp.read_particle_trajectory(pIDs[10])
-        assert pt["x"].iloc[0] == -0.031386006623506546
-        assert pt["vx"].iloc[3] == 5.870406312169507e-05
-        assert pt["vy"].iloc[5] == 4.103916944586672e-05
+        assert pt["x"][0] == -0.031386006623506546
+        assert pt["vx"][3] == 5.870406312169507e-05
+        assert pt["vy"][5] == 4.103916944586672e-05
         assert pt["vz"].shape == (8,)
         with pytest.raises(Exception):
             pt["unknown"]
         x = tp.read_initial_condition(pIDs[10])
-        assert x[1] == pt["x"].iloc[0]
+        assert x[1] == pt["x"][0]
         x = tp.read_final_condition(pIDs[10])
-        assert x[1] == pt["x"].iloc[-1]
+        assert x[1] == pt["x"][-1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
         assert ids[1][1] == 5129
         ax = tp.plot_location(pData[0:2, :])

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -143,17 +143,16 @@ class TestParticles:
         assert tp.__repr__().startswith("Particles")
         assert pIDs[0] == (0, 5121)
         pt = tp.read_particle_trajectory(pIDs[10])
-        assert pt.trajectory[0, 1] == -0.031386006623506546
-        assert pt["u"][3] == 5.870406312169507e-05
-        assert pt["v"][5] == 4.103916944586672e-05
-        assert pt["w"].shape == (8,)
-        assert pt["position"][0].shape == (8,)
+        assert pt["x"].iloc[0] == -0.031386006623506546
+        assert pt["vx"].iloc[3] == 5.870406312169507e-05
+        assert pt["vy"].iloc[5] == 4.103916944586672e-05
+        assert pt["vz"].shape == (8,)
         with pytest.raises(Exception):
             pt["unknown"]
         x = tp.read_initial_condition(pIDs[10])
-        assert x[1] == pt.trajectory[0, 1]
+        assert x[1] == pt["x"].iloc[0]
         x = tp.read_final_condition(pIDs[10])
-        assert x[1] == pt.trajectory[-1, 1]
+        assert x[1] == pt["x"].iloc[-1]
         ids, pData = tp.read_particles_at_time(0.0, doSave=False)
         assert ids[1][1] == 5129
         ax = tp.plot_location(pData[0:2, :])


### PR DESCRIPTION
Built on top of #55 

- Replaced the ParticleTrajectory class with a Polars DataFrame to store test particle trajectory data.
- Updated read_particle_trajectory to return a DataFrame.
- Introduce lazy loading of particle trajectories.
- Modified related methods (save_trajectory_to_csv, get_first_adiabatic_invariant, get_pitch_angle, plot_trajectory) to work with the new DataFrame structure.
- Updated tests and docs to reflect the changes.