### PR TITLE
feat: Add interpolate_at_times function for particle trajectories

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -630,6 +630,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Interpolate particles trajectory at selected times"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flekspy.tp import interpolate_at_times\n",
+    "\n",
+    "interpolate_at_times(traj, [1.5])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flekspy"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python utilities for processing FLEKS data"
 authors = [
     {name = "Yuxi Chen", email = "yuxichen@umich.edu"},

--- a/src/flekspy/tp/__init__.py
+++ b/src/flekspy/tp/__init__.py
@@ -1,1 +1,1 @@
-from .test_particles import FLEKSTP, Indices
+from .test_particles import FLEKSTP, Indices, interpolate_at_times

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray as xr
 import polars as pl
 
-from flekspy.tp.test_particles import interpolate_at_times
+from flekspy.tp import interpolate_at_times
 import flekspy as fs
 from flekspy.util import download_testfile
 
@@ -206,32 +206,7 @@ class TestParticles:
         with pytest.raises(ValueError):
             self.tp.read_particle_trajectory(pID)
 
-    def test_interpolate_at_times(self):
-        # 1. Create a sample DataFrame
-        df = pl.DataFrame(
-            {
-                "time": [0.0, 1.0, 2.0, 3.0, 4.0],
-                "x": [0, 10, 20, 30, 40],
-                "y": [40, 30, 20, 10, 0],
-                "z": [0, 5, 10, 5, 0],
-            }
-        )
-
-        # 2. Define time points for interpolation
-        times_to_interpolate = [0.5, 1.5, 2.5, 3.5]
-
-        # 3. Call the function
-        interpolated_df = interpolate_at_times(df, "time", times_to_interpolate)
-
-        # 4. Assertions
-        assert interpolated_df.shape == (4, 4)
-        assert interpolated_df["time"].to_list() == times_to_interpolate
-        assert np.all(np.isclose(interpolated_df["x"].to_list(), [5.0, 15.0, 25.0, 35.0]))
-        assert np.all(np.isclose(interpolated_df["y"].to_list(), [35.0, 25.0, 15.0, 5.0]))
-        assert np.all(np.isclose(interpolated_df["z"].to_list(), [2.5, 7.5, 7.5, 2.5]))
-
     def test_interpolate_at_times_float32(self):
-        # 1. Create a sample DataFrame with Float32 time
         df = pl.DataFrame(
             {
                 "time": [0.0, 1.0, 2.0, 3.0, 4.0],
@@ -241,19 +216,18 @@ class TestParticles:
             }
         ).with_columns(pl.col("time").cast(pl.Float32))
 
-        # 2. Define time points for interpolation
-        times_to_interpolate = [0.5, 1.5, 2.5, 3.5]
+        times_to_interpolate = [0.5, 1.5, 2.5]
 
-        # 3. Call the function
-        interpolated_df = interpolate_at_times(df, "time", times_to_interpolate)
+        interpolated_df = interpolate_at_times(df, times_to_interpolate)
 
-        # 4. Assertions
-        assert interpolated_df.shape == (4, 4)
+        assert interpolated_df.shape == (3, 4)
         assert interpolated_df["time"].dtype == pl.Float32
-        assert np.all(np.isclose(interpolated_df["time"].to_list(), times_to_interpolate))
-        assert np.all(np.isclose(interpolated_df["x"].to_list(), [5.0, 15.0, 25.0, 35.0]))
-        assert np.all(np.isclose(interpolated_df["y"].to_list(), [35.0, 25.0, 15.0, 5.0]))
-        assert np.all(np.isclose(interpolated_df["z"].to_list(), [2.5, 7.5, 7.5, 2.5]))
+        assert np.all(
+            np.isclose(interpolated_df["time"].to_list(), times_to_interpolate)
+        )
+        assert np.all(np.isclose(interpolated_df["x"].to_list(), [5.0, 15.0, 25.0]))
+        assert np.all(np.isclose(interpolated_df["y"].to_list(), [35.0, 25.0, 15.0]))
+        assert np.all(np.isclose(interpolated_df["z"].to_list(), [2.5, 7.5, 7.5]))
 
 
 def load(files):

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -51,7 +51,6 @@ class TestIDL:
     def test_extract(self):
         ds = fs.load(self.files[1])
         d = ds.interp(x=-28000.0, y=0.0)
-        # The number of variables is 28.
         assert len(d) == 28
 
     def test_slice(self):

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -3,7 +3,9 @@ import os
 import itertools
 import numpy as np
 import xarray as xr
+import polars as pl
 
+from flekspy.tp.test_particles import interpolate_at_times
 import flekspy as fs
 from flekspy.util import download_testfile
 
@@ -203,6 +205,30 @@ class TestParticles:
         )
         with pytest.raises(ValueError):
             self.tp.read_particle_trajectory(pID)
+
+    def test_interpolate_at_times(self):
+        # 1. Create a sample DataFrame
+        df = pl.DataFrame(
+            {
+                "time": [0.0, 1.0, 2.0, 3.0, 4.0],
+                "x": [0, 10, 20, 30, 40],
+                "y": [40, 30, 20, 10, 0],
+                "z": [0, 5, 10, 5, 0],
+            }
+        )
+
+        # 2. Define time points for interpolation
+        times_to_interpolate = [0.5, 1.5, 2.5, 3.5]
+
+        # 3. Call the function
+        interpolated_df = interpolate_at_times(df, "time", times_to_interpolate)
+
+        # 4. Assertions
+        assert interpolated_df.shape == (4, 4)
+        assert interpolated_df["time"].to_list() == times_to_interpolate
+        assert interpolated_df["x"].to_list() == [5.0, 15.0, 25.0, 35.0]
+        assert interpolated_df["y"].to_list() == [35.0, 25.0, 15.0, 5.0]
+        assert interpolated_df["z"].to_list() == [2.5, 7.5, 7.5, 2.5]
 
 
 def load(files):

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -226,9 +226,34 @@ class TestParticles:
         # 4. Assertions
         assert interpolated_df.shape == (4, 4)
         assert interpolated_df["time"].to_list() == times_to_interpolate
-        assert interpolated_df["x"].to_list() == [5.0, 15.0, 25.0, 35.0]
-        assert interpolated_df["y"].to_list() == [35.0, 25.0, 15.0, 5.0]
-        assert interpolated_df["z"].to_list() == [2.5, 7.5, 7.5, 2.5]
+        assert np.all(np.isclose(interpolated_df["x"].to_list(), [5.0, 15.0, 25.0, 35.0]))
+        assert np.all(np.isclose(interpolated_df["y"].to_list(), [35.0, 25.0, 15.0, 5.0]))
+        assert np.all(np.isclose(interpolated_df["z"].to_list(), [2.5, 7.5, 7.5, 2.5]))
+
+    def test_interpolate_at_times_float32(self):
+        # 1. Create a sample DataFrame with Float32 time
+        df = pl.DataFrame(
+            {
+                "time": [0.0, 1.0, 2.0, 3.0, 4.0],
+                "x": [0, 10, 20, 30, 40],
+                "y": [40, 30, 20, 10, 0],
+                "z": [0, 5, 10, 5, 0],
+            }
+        ).with_columns(pl.col("time").cast(pl.Float32))
+
+        # 2. Define time points for interpolation
+        times_to_interpolate = [0.5, 1.5, 2.5, 3.5]
+
+        # 3. Call the function
+        interpolated_df = interpolate_at_times(df, "time", times_to_interpolate)
+
+        # 4. Assertions
+        assert interpolated_df.shape == (4, 4)
+        assert interpolated_df["time"].dtype == pl.Float32
+        assert np.all(np.isclose(interpolated_df["time"].to_list(), times_to_interpolate))
+        assert np.all(np.isclose(interpolated_df["x"].to_list(), [5.0, 15.0, 25.0, 35.0]))
+        assert np.all(np.isclose(interpolated_df["y"].to_list(), [35.0, 25.0, 15.0, 5.0]))
+        assert np.all(np.isclose(interpolated_df["z"].to_list(), [2.5, 7.5, 7.5, 2.5]))
 
 
 def load(files):


### PR DESCRIPTION

Adds a new standalone function `interpolate_at_times` to the `flekspy.tp.test_particles` module.

This function interpolates numeric columns of a Polars DataFrame at specified time points, which is useful for analyzing test particle data at times that were not explicitly saved in the simulation output.

The implementation handles type coercion between Float32 and Float64.

A unit test is added to verify the correctness of the interpolation logic.