### PR TITLE
feat: Make trajectory_cache a selectable option

### DIFF
--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -62,8 +62,11 @@ class FLEKSTP(object):
         iListStart: int = 0,
         iListEnd: int = -1,
         readAllFiles: bool = False,
+        use_cache: bool = False,
     ):
+        self.use_cache = use_cache
         self._trajectory_cache = {}
+
         if isinstance(dirs, str):
             dirs = [dirs]
 
@@ -146,6 +149,11 @@ class FLEKSTP(object):
                 "Particle ID must be a tuple (cpu, id) or an integer index."
             )
 
+        # If caching is not used, read directly and return.
+        if not self.use_cache:
+            return self.read_particle_trajectory(pID)
+
+        # Caching is enabled, use the cache.
         if pID in self._trajectory_cache:
             return self._trajectory_cache[pID]
         else:

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -185,6 +185,22 @@ class TestParticles:
         ax = tp.plot_trajectory(pIDs[0])
         assert ax[1][0].get_xlim()[1] == 2.140599811077118
 
+    def test_particle_cache(self):
+        from flekspy import FLEKSTP
+
+        dirs = ("tests/data/test_particles",)
+        tp = FLEKSTP(dirs, iSpecies=1, use_cache=True)
+        pID = tp.getIDs()[0]
+
+        # First access, should be read from file
+        trajectory1 = tp[pID]
+
+        # Second access, should be from cache
+        trajectory2 = tp[pID]
+
+        # Check if they are the same object
+        assert trajectory1 is trajectory2
+
     def test_read_particle_trajectory_key_error(self):
         with pytest.raises(KeyError):
             self.tp.read_particle_trajectory((-1, -1))


### PR DESCRIPTION
We introduced a `use_cache` parameter to the `FLEKSTP` class constructor, allowing to enable or disable the trajectory caching mechanism.

By default, caching is now disabled to prevent excessive memory consumption. When you pass `use_cache=True` during instantiation, the class will cache particle trajectories in memory as they are accessed, which can speed up subsequent lookups for the same particle.