### PR TITLE
feat: Add analyze_drift method to FLEKSTP class

### DIFF
--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -282,6 +282,7 @@ class TestParticles:
         assert "Wp_integrated" in df_drifts.columns
         plot_integrated_energy(df_drifts)
         tp.analyze_drifts(pid)
+        tp.analyze_drift(pid, "ExB")
 
         rg2rc = tp.get_gyroradius_to_curvature_ratio(pid)[0]
         assert np.isclose(rg2rc, 3.082973481811359e-05)


### PR DESCRIPTION
This commit introduces a new method, `analyze_drift`, to the `FLEKSTP` class in the test particle module.

The `analyze_drift` method provides a way to analyze a specific type of plasma drift for a given particle trajectory. It accepts a particle ID and a drift type ('ExB', 'gradient', 'curvature', or 'polarization') as input.

For the selected drift, the method generates a comprehensive 4-panel plot that visualizes:
1.  The components of the drift velocity.
2.  The components of the electric field.
3.  The rate of energy change (q * E . v_drift).
4.  The integrated energy change along the trajectory.

This functionality allows for detailed analysis of individual drift mechanisms and their contribution to particle energization.