### PR TITLE
Add test for guiding center energy change calculation

### DIFF
--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -298,6 +298,34 @@ class TestParticles:
         )
         assert s_up_dn[1]["time"][1] == 1.2570836544036865
 
+    def test_energy_change_guiding_center(self):
+        tp = self.FLEKSTP(self.dirs[1], iSpecies=1, use_cache=True, unit="SI")
+        pid = tp.getIDs()[0]
+
+        df = tp.get_energy_change_guiding_center(pid)
+
+        # Check if the output is a Polars DataFrame
+        assert isinstance(df, pl.DataFrame)
+
+        # Check for expected columns
+        expected_columns = {
+            "time",
+            "dW_parallel",
+            "dW_betatron",
+            "dW_fermi",
+            "dW_total",
+        }
+        assert expected_columns.issubset(df.columns)
+
+        # Check that dW_total is the sum of the components
+        total_sum = df["dW_parallel"] + df["dW_betatron"] + df["dW_fermi"]
+        assert np.allclose(df["dW_total"].to_numpy(), total_sum.to_numpy())
+
+        # Check that the number of rows is correct
+        pt_len = len(tp[pid].collect())
+        assert len(df) == pt_len
+
+
 def load(files):
     """
     Benchmarking flekspy loading.


### PR DESCRIPTION
This commit introduces a new method `get_energy_change_guiding_center` to the `FLEKSTP` class in the test particle module. This method implements another way of computing the change of energy of a single particle based on the guiding center approximation.

The formula is:
dW/dt = q*E_parallel*v_parallel + mu*(∂B/∂t + u_E.∇B) + m*v_parallel^2*(u_E.κ)

The implementation calculates the three terms of the equation (parallel acceleration, Betatron acceleration, and Fermi acceleration) and returns them in a Polars DataFrame. The method handles both "planetary" and "SI" units and reuses existing helper functions for consistency and correctness.