### PR TITLE
feat: Add analyze_drifts_energy_change method

### DIFF
--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -1461,6 +1461,116 @@ class FLEKSTP(object):
         else:
             plt.show()
 
+    def analyze_drifts_energy_change(
+        self,
+        pID: Tuple[int, int],
+        mass=proton_mass,
+        charge=elementary_charge,
+        outname=None,
+    ):
+        """
+        Analyzes and plots the energy changes for each term in the guiding center
+        approximation.
+
+        This method computes the parallel, Betatron, and Fermi accelerations using
+        `get_energy_change_guiding_center`. It also calculates the total kinetic
+        energy change and treats the difference between the kinetic energy change
+        and the sum of the guiding center terms (dW_total) as the non-adiabatic term.
+
+        The method generates a plot with four subplots:
+        1. dW_parallel: Energy change due to parallel electric fields.
+        2. dW_betatron: Energy change due to the Betatron effect.
+        3. dW_fermi: Energy change due to Fermi acceleration.
+        4. dW_total and Non-adiabatic term: The sum of the above terms compared
+           with the non-adiabatic heating component.
+
+        Args:
+            pID (Tuple[int, int]): The particle ID (cpu, id).
+            mass (float): The mass of the particle in kg. Defaults to proton_mass.
+            charge (float): The charge of the particle in Coulombs.
+                            Defaults to elementary_charge.
+            outname (str, optional): If provided, the plot is saved to this
+                                     filename instead of being shown. Defaults to None.
+        """
+        # --- 1. Get Guiding Center Energy Changes ---
+        df_gc = self.get_energy_change_guiding_center(
+            pID, mass=mass, charge=charge
+        )
+        time = df_gc["time"]
+        dW_parallel = df_gc["dW_parallel"]
+        dW_betatron = df_gc["dW_betatron"]
+        dW_fermi = df_gc["dW_fermi"]
+        dW_total = df_gc["dW_total"]
+
+        # --- 2. Get Kinetic Energy Change Rate ---
+        pt_lazy = self[pID]
+        dke_dt = self.get_kinetic_energy_change_rate(pt_lazy, mass=mass)
+
+        # --- 3. Calculate Non-adiabatic Term ---
+        # Ensure dke_dt is aligned with the time from df_gc if lengths differ
+        # (though they should be the same)
+        if len(dke_dt) != len(dW_total):
+            # This case should be handled based on expected behavior,
+            # for now, we assume they align.
+            logger.warning(
+                "Mismatch in length between kinetic energy and guiding center calculations."
+            )
+            # A more robust solution might involve interpolation if time arrays differ
+            pass
+
+        non_adiabatic_term = dke_dt - dW_total
+
+        # --- 4. Plotting ---
+        fig, axes = plt.subplots(
+            nrows=4, ncols=1, figsize=(12, 10), sharex=True, constrained_layout=True
+        )
+        fig.suptitle(f"Energy Change Analysis for Particle {pID}", fontsize=16)
+
+        # Subplot 1: dW_parallel
+        axes[0].plot(time, dW_parallel, label=r"$dW_{\parallel}/dt$")
+        axes[0].set_ylabel("Rate [eV/s]")
+        axes[0].set_title("Parallel Acceleration")
+        axes[0].grid(True, linestyle="--", alpha=0.6)
+
+        # Subplot 2: dW_betatron
+        axes[1].plot(time, dW_betatron, label="$dW_{betatron}/dt$", color="tab:orange")
+        axes[1].set_ylabel("Rate [eV/s]")
+        axes[1].set_title("Betatron Acceleration")
+        axes[1].grid(True, linestyle="--", alpha=0.6)
+
+        # Subplot 3: dW_fermi
+        axes[2].plot(time, dW_fermi, label="$dW_{fermi}/dt$", color="tab:green")
+        axes[2].set_ylabel("Rate [eV/s]")
+        axes[2].set_title("Fermi Acceleration")
+        axes[2].grid(True, linestyle="--", alpha=0.6)
+
+        # Subplot 4: dW_total and Non-adiabatic term
+        axes[3].plot(time, dW_total, label="$dW_{total}/dt$ (GC)", color="tab:red")
+        axes[3].plot(
+            time,
+            non_adiabatic_term,
+            label="Non-adiabatic",
+            color="tab:purple",
+            linestyle="--",
+        )
+        axes[3].plot(
+            time, dke_dt, label="d(KE)/dt", color="black", linestyle=":", alpha=0.7
+        )
+        axes[3].set_ylabel("Rate [eV/s]")
+        axes[3].set_title("Total and Non-Adiabatic Energy Change")
+        axes[3].grid(True, linestyle="--", alpha=0.6)
+        axes[3].legend(fontsize="medium")
+
+        axes[-1].set_xlabel("Time [s]", fontsize=14)
+        for ax in axes:
+            ax.set_xlim(left=time.min(), right=time.max())
+
+        if outname is not None:
+            plt.savefig(outname, bbox_inches="tight")
+            plt.close(fig)
+        else:
+            plt.show()
+
     def analyze_drift(
         self,
         pID: tuple[int, int],

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -1527,23 +1527,19 @@ class FLEKSTP(object):
         )
         fig.suptitle(f"Energy Change Analysis for Particle {pID}", fontsize=16)
 
-        # Subplot 1: dW_parallel
-        axes[0].plot(time, dW_parallel, label=r"$dW_{\parallel}/dt$")
-        axes[0].set_ylabel("Rate [eV/s]")
-        axes[0].set_title("Parallel Acceleration")
-        axes[0].grid(True, linestyle="--", alpha=0.6)
+        # Subplots for individual energy change terms
+        plot_configs = [
+            {"data": dW_parallel, "label": r"$dW_{\parallel}/dt$", "title": "Parallel Acceleration"},
+            {"data": dW_betatron, "label": "$dW_{betatron}/dt$", "title": "Betatron Acceleration", "color": "tab:orange"},
+            {"data": dW_fermi, "label": "$dW_{fermi}/dt$", "title": "Fermi Acceleration", "color": "tab:green"},
+        ]
 
-        # Subplot 2: dW_betatron
-        axes[1].plot(time, dW_betatron, label="$dW_{betatron}/dt$", color="tab:orange")
-        axes[1].set_ylabel("Rate [eV/s]")
-        axes[1].set_title("Betatron Acceleration")
-        axes[1].grid(True, linestyle="--", alpha=0.6)
-
-        # Subplot 3: dW_fermi
-        axes[2].plot(time, dW_fermi, label="$dW_{fermi}/dt$", color="tab:green")
-        axes[2].set_ylabel("Rate [eV/s]")
-        axes[2].set_title("Fermi Acceleration")
-        axes[2].grid(True, linestyle="--", alpha=0.6)
+        for i, config in enumerate(plot_configs):
+            ax = axes[i]
+            ax.plot(time, config["data"], label=config["label"], color=config.get("color"))
+            ax.set_ylabel("Rate [eV/s]")
+            ax.set_title(config["title"])
+            ax.grid(True, linestyle="--", alpha=0.6)
 
         # Subplot 4: dW_total and Non-adiabatic term
         axes[3].plot(time, dW_total, label="$dW_{total}/dt$ (GC)", color="tab:red")

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -1510,13 +1510,14 @@ class FLEKSTP(object):
         # Ensure dke_dt is aligned with the time from df_gc if lengths differ
         # (though they should be the same)
         if len(dke_dt) != len(dW_total):
-            # This case should be handled based on expected behavior,
-            # for now, we assume they align.
-            logger.warning(
-                "Mismatch in length between kinetic energy and guiding center calculations."
+            # This case should not happen if the underlying data is consistent.
+            # Raise an error to prevent crashing later.
+            msg = (
+                f"Mismatch in length between kinetic energy and guiding center calculations: "
+                f"len(dke_dt)={len(dke_dt)}, len(dW_total)={len(dW_total)}"
             )
-            # A more robust solution might involve interpolation if time arrays differ
-            pass
+            logger.error(msg)
+            raise ValueError(msg)
 
         non_adiabatic_term = dke_dt - dW_total
 

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -326,13 +326,12 @@ class TestParticles:
         assert len(df) == pt_len
         #TODO Check numerical values!
 
-    def test_analyze_drifts_energy_change(self):
+    def test_analyze_drifts_energy_change(self, tmp_path):
         tp = self.FLEKSTP(self.dirs[1], iSpecies=1, use_cache=True, unit="SI")
         pid = tp.getIDs()[0]
-        outname = "test_energy_change.png"
-        tp.analyze_drifts_energy_change(pid, outname=outname)
-        assert os.path.exists(outname)
-        os.remove(outname)
+        outname = tmp_path / "test_energy_change.png"
+        tp.analyze_drifts_energy_change(pid, outname=str(outname))
+        assert outname.exists()
 
 
 def load(files):

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -326,6 +326,14 @@ class TestParticles:
         assert len(df) == pt_len
         #TODO Check numerical values!
 
+    def test_analyze_drifts_energy_change(self):
+        tp = self.FLEKSTP(self.dirs[1], iSpecies=1, use_cache=True, unit="SI")
+        pid = tp.getIDs()[0]
+        outname = "test_energy_change.png"
+        tp.analyze_drifts_energy_change(pid, outname=outname)
+        assert os.path.exists(outname)
+        os.remove(outname)
+
 
 def load(files):
     """


### PR DESCRIPTION
This commit introduces a new method, `analyze_drifts_energy_change`, to the `FLEKSTP` class in the test particle module. This method provides a comprehensive analysis of the energy changes in a particle's trajectory based on the guiding center approximation.

The `analyze_drifts_energy_change` method generates a multi-panel plot that visualizes the rate of energy change ([eV/s]) for different guiding center terms:
- Parallel acceleration (`dW_parallel`)
- Betatron acceleration (`dW_betatron`)
- Fermi acceleration (`dW_fermi`)

A fourth subplot compares the total energy change from the guiding center approximation (`dW_total`) with the total change in kinetic energy (`d(KE)/dt`) and the non-adiabatic component of the energy change.

A test case has been added to ensure that the new method runs without errors and produces a plot.