### PR TITLE
feat: Use adiabaticity parameter in test particle module

### DIFF
--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -740,7 +740,7 @@
     "- Gradient drift velocity: `tp.get_gradient_drift(pid)`\n",
     "- Polarization drift velocity: `tp.get_polarization_drift(pid)`\n",
     "\n",
-    "The first adiabatic assumption can be checked by comparing the ratio between the gyroradius and the curvature length $r_L / r_c$ via `get_gyroradius_to_curvature_ratio`. If $r_L / r_c \\ll 1$, then the gyromotion can be savely ignored.\n"
+    "The first adiabatic assumption can be checked by comparing the ratio between the curvature length and the gyroradius $r_c / r_L$ via `get_adiabaticity_parameter`. If $r_c / r_L \\gg 1$, then the gyromotion can be savely ignored.\n"
    ]
   },
   {

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -792,9 +792,6 @@ class FLEKSTP(object):
         sin_alpha_sq = 1 - (v_dot_b / (v_mag_sq.sqrt() * b_mag + epsilon)) ** 2
         v_perp = (v_mag_sq * sin_alpha_sq).sqrt()
 
-        # Expression for gyroradius
-        r_g = (self.mass * v_perp) / (abs(self.charge) * b_mag) * 1e9  # [km]
-
         # Expression for curvature radius
         lf_curv = self._calculate_curvature(pt_lazy)
         kappa_mag = (
@@ -802,12 +799,19 @@ class FLEKSTP(object):
         ).sqrt()
 
         if self.unit == "planetary":
-            factor = EARTH_RADIUS_KM  # conversion factor
+            # v_perp [km/s], b_mag [nT] -> r_g [km]
+            r_g = (self.mass * v_perp) / (abs(self.charge) * b_mag + epsilon) * 1e9
+            # kappa_mag [1/RE] -> r_c [km]
+            r_c_factor = EARTH_RADIUS_KM
         elif self.unit == "SI":
-            factor = 1e-3  # conversion factor
+            # v_perp [m/s], b_mag [T] -> r_g [m]
+            r_g = (self.mass * v_perp) / (abs(self.charge) * b_mag + epsilon)
+            # kappa_mag [1/m] -> r_c [m]
+            r_c_factor = 1.0
         else:
             raise ValueError(f"Unknown unit: '{self.unit}'. Must be 'planetary' or 'SI'.")
-        r_c = (1 / (kappa_mag + epsilon)) * factor  # [km]
+
+        r_c = (1 / (kappa_mag + epsilon)) * r_c_factor
 
         ratio_expr = (r_c / r_g).alias("adiabaticity")
 

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -284,8 +284,8 @@ class TestParticles:
         tp.analyze_drifts(pid)
         tp.analyze_drift(pid, "ExB")
 
-        rg2rc = tp.get_gyroradius_to_curvature_ratio(pid)[0]
-        assert np.isclose(rg2rc, 3.082973481811359e-05)
+        rc2rl = tp.get_adiabaticity_parameter(pid)[0]
+        assert np.isclose(rc2rl, 3.333809141473975e+16)
 
         tcross = tp.find_shock_crossing_time(tp.getIDs()[0], b_threshold_factor=1)
         assert tcross == 0.0


### PR DESCRIPTION
The method for computing the ratio between the particle gyroradius and the field curvature has been updated.

The adiabaticity parameter is now calculated as the field curvature radius divided by the gyroradius (rc/rg). This is the inverse of the previous calculation.

The method `get_gyroradius_to_curvature_ratio` has been renamed to `get_adiabaticity_parameter` and its logic has been updated.

The `analyze_drifts` method has been updated to use the new method and the plot now reflects the new adiabaticity parameter, with the non-adiabatic threshold set to 1.0.