### PR TITLE
Fix unordered vectors in PIC-coupled data

### DIFF
--- a/src/flekspy/idl/idl.py
+++ b/src/flekspy/idl/idl.py
@@ -54,12 +54,10 @@ def _read_and_process_data(filename):
         dims.append(dim_name)
         dim_idx = varnames.index(dim_name)
 
-        slicer_min = [0] * 3
-        slicer_max = [0] * 3
-        slicer_max[i] = -1
-
-        start = array[dim_idx, slicer_min[0], slicer_min[1], slicer_min[2]]
-        stop = array[dim_idx, slicer_max[0], slicer_max[1], slicer_max[2]]
+        start = array[dim_idx, 0, 0, 0]
+        stop_slicer = [0] * 3
+        stop_slicer[i] = -1
+        stop = array[(dim_idx,) + tuple(stop_slicer)]
 
         coords[dim_name] = np.linspace(start, stop, attrs["grid"][i])
 

--- a/src/flekspy/idl/idl.py
+++ b/src/flekspy/idl/idl.py
@@ -53,9 +53,15 @@ def _read_and_process_data(filename):
         dim_name = attrs["dims"][i]
         dims.append(dim_name)
         dim_idx = varnames.index(dim_name)
-        slicer = [0] * 3
-        slicer[i] = slice(None, attrs["grid"][i])
-        coords[dim_name] = np.squeeze(array[dim_idx, slicer[0], slicer[1], slicer[2]])
+
+        slicer_min = [0] * 3
+        slicer_max = [0] * 3
+        slicer_max[i] = -1
+
+        start = array[dim_idx, slicer_min[0], slicer_min[1], slicer_min[2]]
+        stop = array[dim_idx, slicer_max[0], slicer_max[1], slicer_max[2]]
+
+        coords[dim_name] = np.linspace(start, stop, attrs["grid"][i])
 
     data_vars = {}
     for i, var_name in enumerate(varnames):


### PR DESCRIPTION
When coupling with PIC, the output of *.out files may contain domains that are not covered by PIC. In these uncovered domains, the coordinates are stored as zeros in the array. This can lead to unordered coordinate vectors when reading the data.

This commit fixes this issue by recreating the coordinate 1D arrays using `np.linspace`, assuming that the mesh is uniform. The start and end points for the linspace are taken from the corner points of the data array.

Fixes #85