### PR TITLE
feat: Add work-energy verification plot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flekspy"
-version = "0.5.17"
+version = "0.5.18"
 description = "Python utilities for processing FLEKS data"
 authors = [
     {name = "Yuxi Chen", email = "yuxichen@umich.edu"},

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -549,24 +549,6 @@ class FLEKSTP(object):
 
         return pl.Series("dke_dt", dke_dt)
 
-    def get_kinetic_energy_change_rate(
-        self, pt_lazy: pl.LazyFrame
-    ) -> pl.Series:
-        """
-        Calculates the rate of change of kinetic energy in [eV/s].
-        """
-        # Select only necessary columns before collecting to improve performance.
-        collected = pt_lazy.select(["time", "vx", "vy", "vz"]).collect()
-        time = collected["time"].to_numpy()
-        vx = collected["vx"].to_numpy()
-        vy = collected["vy"].to_numpy()
-        vz = collected["vz"].to_numpy()
-
-        ke = self.get_kinetic_energy(vx, vy, vz)
-        dke_dt = np.gradient(ke, time)
-
-        return pl.Series("dke_dt", dke_dt)
-
     def get_pitch_angle(self, pID):
         pt_lazy = self[pID]
         # Pitch Angle Calculation

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -333,6 +333,13 @@ class TestParticles:
         tp.analyze_drifts_energy_change(pid, outname=str(outname))
         assert outname.exists()
 
+    def test_work_energy_verification(self, tmp_path):
+        tp = self.FLEKSTP(self.dirs[1], iSpecies=1, use_cache=True, unit="SI")
+        pid = tp.getIDs()[0]
+        outname = tmp_path / "test_work_energy.png"
+        tp.plot_work_energy_verification(pid, outname=str(outname))
+        assert outname.exists()
+
 
 def load(files):
     """


### PR DESCRIPTION
This commit introduces a new function `plot_work_energy_verification` to the `FLEKSTP` class in the `flekspy.tp.test_particles` module.

This function provides a way to verify the work-energy theorem for a particle's trajectory by generating a two-panel plot:
- The first panel compares the rate of change of kinetic energy (`d(KE)/dt`) with the rate of work done by the electric field (`q * E.v`).
- The second panel compares the integrated change in kinetic energy (`ΔKE`) with the total work done by the electric field.

This helps in validating the simulation data and understanding the energy transfer processes for individual particles.