### PR TITLE
feat: Enhance FLEKSTP repr with more particle info

### DIFF
--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -150,6 +150,9 @@ class FLEKSTP(object):
     def __repr__(self):
         return (
             f"Particles species ID: {self.iSpecies}\n"
+            f"Particle mass [kg]  : {self.mass}\n"
+            f"Particle charge [C] : {self.charge}\n"
+            f"Unit system         : {self.unit}\n"
             f"Number of particles : {len(self.IDs)}\n"
             f"First time tag      : {self.filetime[0]}\n"
             f"Last  time tag      : {self.filetime[-1]}\n"

--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -154,8 +154,8 @@ class FLEKSTP(object):
             f"Particle charge [C] : {self.charge}\n"
             f"Unit system         : {self.unit}\n"
             f"Number of particles : {len(self.IDs)}\n"
-            f"First time tag      : {self.filetime[0]}\n"
-            f"Last  time tag      : {self.filetime[-1]}\n"
+            f"First time tag      : {self.filetime[0] if self.filetime else 'N/A'}\n"
+            f"Last  time tag      : {self.filetime[-1] if self.filetime else 'N/A'}\n"
         )
 
     def __len__(self):


### PR DESCRIPTION
The `__repr__` method for the `FLEKSTP` class has been updated to provide more comprehensive information about the particle setup.

This change adds the following details to the representation string:
- Particle mass (in kg)
- Particle charge (in C)
- The unit system being used ('planetary' or 'SI')

This will make it easier for users to quickly inspect the key properties of a `FLEKSTP` object at a glance.