### PR TITLE
feat: Use dynamic start time for x-axis in analyze_drifts

### DIFF
--- a/src/flekspy/tp/test_particles.py
+++ b/src/flekspy/tp/test_particles.py
@@ -1471,7 +1471,7 @@ class FLEKSTP(object):
         axes[-1].grid(True, linestyle="--", alpha=0.6)
 
         for ax in axes:
-            ax.set_xlim(left=0, right=pt["time"][-1])
+            ax.set_xlim(left=pt["time"][0], right=pt["time"][-1])
 
         axes[-1].set_xlabel("Time [s]", fontsize=14)
 


### PR DESCRIPTION
The `analyze_drifts` function previously used a hardcoded value of 0 for the left limit of the x-axis in its plots. This change updates the function to use the first timestamp from the particle data (`pt["time"][0]`) as the starting point for the x-axis.

This makes the plots more general and accurate, especially for time series that do not start at or near t=0.