### PR TITLE
feat: Make AMReXParticleData the default loader for particle data

### DIFF
--- a/src/flekspy/__init__.py
+++ b/src/flekspy/__init__.py
@@ -8,6 +8,7 @@ from itertools import islice
 from flekspy.idl import read_idl, IDLAccessor
 from flekspy.yt import FLEKSData, extract_phase
 from flekspy.tp import FLEKSTP
+from flekspy.amrex import AMReXParticleData
 import xarray as xr
 
 
@@ -55,6 +56,9 @@ def load(
     elif filepath.suffix in [".out", ".outs"]:
         return read_idl(filename)
     elif basename.endswith("_amrex"):
-        return FLEKSData(filename, readFieldData)
+        if "particle" in basename:
+            return AMReXParticleData(filename)
+        else:
+            return FLEKSData(filename, readFieldData)
     else:
         raise Exception("Error: unknown file format!")

--- a/tests/test_evaluate_expression.py
+++ b/tests/test_evaluate_expression.py
@@ -20,7 +20,7 @@ if not os.path.isdir(
 
 
 class TestEvaluateExpression:
-    files = ("3d*amrex",)
+    files = ("3d_region*amrex",)
     files = [os.path.join("tests/data/", file) for file in files]
 
     def test_evaluate_expression(self):

--- a/tests/test_fleks.py
+++ b/tests/test_fleks.py
@@ -85,7 +85,7 @@ class TestIDL:
 
 
 class TestAMReX:
-    files = ("z=0_fluid_region0_0_t00001640_n00010142.out", "3d*amrex")
+    files = ("z=0_fluid_region0_0_t00001640_n00010142.out", "3d_region*amrex")
     files = [os.path.join("tests/data/", file) for file in files]
 
     def test_load(self):
@@ -141,6 +141,10 @@ class TestAMReX:
         )
         f = fs.extract_phase(pp)
         assert f[0].size == 16 and f[2].shape == (16, 16)
+
+    def test_amrex_particle_loader(self):
+        ds = fs.load("tests/data/3d_particle*amrex")
+        assert isinstance(ds, fs.amrex.AMReXParticleData)
 
 
 class TestParticles:


### PR DESCRIPTION
The `load` function in `flekspy/__init__.py` is updated to use the new `AMReXParticleData` loader for AMReX files that contain "particle" in their basename.

- The `load` function now inspects the filename for the presence of "particle" in addition to the "_amrex" suffix.
- If both are present, `AMReXParticleData` is used.
- Otherwise, for files with only the "_amrex" suffix, it falls back to the `FLEKSData` (yt) loader.

The test suite has been updated to reflect this change. A separate test data directory was created for particle data, and a new test was added to verify the new loading logic.