### PR TITLE
docs: fix LaTeX rendering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ autoapi_dirs = ["../src"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # Update MathJax configuration to prevent myst-nb from interfering with it
+# Disabling this setting resolves an issue where myst-nb modifies the MathJax configuration,
+# leading to incorrect rendering of LaTeX equations in Jupyter notebooks.
 myst_update_mathjax = False
 
 # If True, the build process is continued even if a runtime exception occurs:


### PR DESCRIPTION
The myst-nb extension was interfering with the MathJax configuration, causing LaTeX equations in Jupyter notebooks to render incorrectly in the Sphinx-generated HTML documentation.

This change disables the `myst_update_mathjax` setting in `docs/conf.py` to prevent this interference and restore proper LaTeX rendering.