### PR TITLE
feat: Add method to save multiple particle trajectories to HDF5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "xarray>=2024.6.0",
     "polars>=0.20.21,<1",
     "xugrid>=0.14.2,<1",
+    "pandas>=2.2.2,<3",
+    "tables>=3.9.2,<4",
+    "pyarrow>=16.1.0,<17",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Adds a new `save_trajectories` method to the `FLEKSTP` class.

This method allows saving the trajectories of multiple particles to a single HDF5 file. Each particle's trajectory is stored as a separate dataset under a hierarchical key based on its CPU and particle ID (e.g., `/cpu_0/id_123`).

The implementation uses `pandas` and `tables` for HDF5 writing and adds them as project dependencies. `pyarrow` is also added as a dependency to facilitate the conversion from `polars` to `pandas` DataFrames.

A corresponding unit test has been added to verify the new functionality.