### PR TITLE
feat: Add range parameter to plot_phase

### DIFF
--- a/src/flekspy/amrex.py
+++ b/src/flekspy/amrex.py
@@ -390,7 +390,7 @@ class AMReXParticleData:
         x_variable: str,
         y_variable: str,
         bins: Union[int, Tuple[int, int]] = 100,
-        range: Optional[List[List[float]]] = None,
+        hist_range: Optional[List[List[float]]] = None,
         x_range: Optional[Tuple[float, float]] = None,
         y_range: Optional[Tuple[float, float]] = None,
         z_range: Optional[Tuple[float, float]] = None,
@@ -417,7 +417,7 @@ class AMReXParticleData:
                                            tuple for different numbers of bins in the
                                            x and y dimension, respectively.
                                            Defaults to 100.
-            range (list of lists, optional): The leftmost and rightmost edges of the
+            hist_range (list of lists, optional): The leftmost and rightmost edges of the
                                              bins along each dimension. It should be
                                              in the format [[xmin, xmax], [ymin, ymax]].
                                              Defaults to None.
@@ -472,7 +472,7 @@ class AMReXParticleData:
         else:
             cbar_label = "Particle Count"
 
-        H, xedges, yedges = np.histogram2d(x_data, y_data, bins=bins, range=range, weights=weights)
+        H, xedges, yedges = np.histogram2d(x_data, y_data, bins=bins, range=hist_range, weights=weights)
 
         if normalize:
             total = H.sum()

--- a/tests/test_amrex_loader.py
+++ b/tests/test_amrex_loader.py
@@ -142,9 +142,9 @@ def test_plot_phase_no_particles(mock_logger, mock_plot_components):
 
 
 @patch("numpy.histogram2d")
-def test_plot_phase_with_range(mock_histogram2d, mock_plot_components):
+def test_plot_phase_with_hist_range(mock_histogram2d, mock_plot_components):
     """
-    Tests that the range parameter is correctly passed to numpy.histogram2d.
+    Tests that the hist_range parameter is correctly passed to numpy.histogram2d.
     """
     mock_pdata = MagicMock(spec=AMReXParticleData)
     mock_pdata.header = MagicMock()
@@ -158,7 +158,7 @@ def test_plot_phase_with_range(mock_histogram2d, mock_plot_components):
 
     custom_range = [[0.1, 0.9], [0.2, 0.8]]
     AMReXParticleData.plot_phase(
-        mock_pdata, x_variable="x", y_variable="y", range=custom_range
+        mock_pdata, x_variable="x", y_variable="y", hist_range=custom_range
     )
 
     mock_histogram2d.assert_called_once()


### PR DESCRIPTION
This commit introduces a new optional `range` parameter to the `plot_phase` method in the `AMReXParticleData` class. This parameter is passed directly to the `numpy.histogram2d` function, allowing users to control the boundaries of the 2D histogram.

A new unit test has been added to verify that the `range` parameter is correctly passed to `numpy.histogram2d`.