### PR TITLE
Adds an `ax` parameter to `plot_phase`

### DIFF
--- a/src/flekspy/amrex.py
+++ b/src/flekspy/amrex.py
@@ -418,6 +418,7 @@ class AMReXParticleData:
         xlabel: Optional[str] = None,
         ylabel: Optional[str] = None,
         ax: Optional[Axes] = None,
+        add_colorbar: bool = True,
         **imshow_kwargs: Any,
     ) -> Optional[Tuple[Figure, Axes]]:
         """
@@ -455,6 +456,8 @@ class AMReXParticleData:
             ax (matplotlib.axes.Axes, optional): An existing axes object to plot on.
                                                  If None, a new figure and axes are created.
                                                  Defaults to None.
+            add_colorbar (bool, optional): If True, a colorbar is added to the plot.
+                                           Defaults to True.
             **imshow_kwargs: Additional keyword arguments to be passed to `ax.imshow()`.
                              This can be used to control colormaps (`cmap`), normalization (`norm`), etc.
 
@@ -544,10 +547,11 @@ class AMReXParticleData:
         ax.set_ylabel(final_ylabel, fontsize="x-large")
         ax.minorticks_on()
 
-        divider = make_axes_locatable(ax)
-        cax = divider.append_axes("right", size="3%", pad=0.05)
-        cbar = fig.colorbar(im, cax=cax)
-        cbar.set_label(cbar_label)
+        if add_colorbar:
+            divider = make_axes_locatable(ax)
+            cax = divider.append_axes("right", size="3%", pad=0.05)
+            cbar = fig.colorbar(im, cax=cax)
+            cbar.set_label(cbar_label)
 
         # --- 8. Return the plot objects ---
         return fig, ax

--- a/tests/test_amrex_loader.py
+++ b/tests/test_amrex_loader.py
@@ -156,6 +156,27 @@ def test_plot_phase_with_existing_axes(mock_plot_components):
     assert mock_ax.imshow.called
 
 
+def test_plot_phase_no_colorbar(mock_plot_components):
+    """
+    Tests that the colorbar is not created when add_colorbar=False.
+    """
+    mock_fig = mock_plot_components["fig"]
+    mock_ax = mock_plot_components["ax"]
+
+    mock_pdata = MagicMock(spec=AMReXParticleData)
+    mock_pdata.header = MagicMock()
+    mock_pdata.header.real_component_names = ["x", "y"]
+    mock_pdata.rdata = np.random.rand(100, 2)
+
+    AMReXParticleData.plot_phase(
+        mock_pdata, x_variable="x", y_variable="y", add_colorbar=False
+    )
+
+    # Assert that the colorbar creation logic was not called
+    mock_plot_components["make_axes_locatable"].assert_not_called()
+    mock_fig.colorbar.assert_not_called()
+
+
 @patch("flekspy.amrex.logger")
 def test_plot_phase_no_particles(mock_logger, mock_plot_components):
     """


### PR DESCRIPTION
This change enhances the flexibility of the plotting function, enabling its integration into more complex, multi-panel figures.

- Modified `plot_phase` to accept an optional `ax: Optional[Axes] = None`.
- If `ax` is provided, the function plots on it; otherwise, it creates a new figure and axes as before.