### PR TITLE
feat: Add KDE option to plot_phase

### DIFF
--- a/src/flekspy/amrex/plotting.py
+++ b/src/flekspy/amrex/plotting.py
@@ -149,11 +149,6 @@ class AMReXPlottingMixin:
         else:
             cbar_label = "Particle Count"
         if use_kde:
-            if weights is not None:
-                logger.warning(
-                    "Weights are not supported for KDE. They will be ignored."
-                )
-
             xmin, xmax = (
                 (hist_range[0][0], hist_range[0][1])
                 if hist_range
@@ -169,12 +164,14 @@ class AMReXPlottingMixin:
             X, Y = np.mgrid[xmin:xmax:grid_complex, ymin:ymax:grid_complex]
             positions = np.vstack([X.ravel(), Y.ravel()])
             values = np.vstack([x_data, y_data])
-            kernel = gaussian_kde(values, bw_method=kde_bandwidth)
+            kernel = gaussian_kde(values, bw_method=kde_bandwidth, weights=weights)
             H = np.reshape(kernel(positions).T, X.shape)
             xedges = np.linspace(xmin, xmax, kde_grid_size + 1)
             yedges = np.linspace(ymin, ymax, kde_grid_size + 1)
-            cbar_label = "Density"
-
+            if weights is not None:
+                cbar_label = "Weighted Density"
+            else:
+                cbar_label = "Density"
         else:
             H, xedges, yedges = np.histogram2d(
                 x_data, y_data, bins=bins, range=hist_range, weights=weights


### PR DESCRIPTION
Adds a Kernel Density Estimation (KDE) method to the `plot_phase` function in `flekspy.amrex.plotting`. Users can now choose to visualize the particle phase space density using a KDE plot instead of a 2D histogram by setting the `use_kde` parameter to `True`.

The following new parameters have been added to `plot_phase`:
- `use_kde`: A boolean to enable or disable the KDE plot.
- `kde_bandwidth`: The bandwidth for the KDE, which can be 'scott', 'silverman', a scalar, or a callable.
- `kde_grid_size`: The number of grid points in each dimension for the KDE.

The implementation uses `scipy.stats.gaussian_kde` to perform the density estimation. A new test has been added to verify the functionality, including the correct use of the new parameters.