### PR TITLE
Adds a new method, get_gmm_parameters, to the AMReXParticleData class.

### DIFF
--- a/src/flekspy/amrex/particle_data.py
+++ b/src/flekspy/amrex/particle_data.py
@@ -469,9 +469,8 @@ class AMReXParticleData(AMReXPlottingMixin):
 
         return gmm
 
-    def get_gmm_parameters(
-        self, gmm: GaussianMixture, isotropic: bool = True
-    ) -> List[dict]:
+    @staticmethod
+    def get_gmm_parameters(gmm: GaussianMixture, isotropic: bool = True) -> List[dict]:
         """
         Extracts the physical parameters (centers and temperatures) from a fitted GMM.
 

--- a/tests/test_gmm_parameters.py
+++ b/tests/test_gmm_parameters.py
@@ -3,18 +3,7 @@ import pytest
 from sklearn.mixture import GaussianMixture
 from unittest.mock import MagicMock
 
-# Create a mock for the AMReXParticleData class to isolate the method
 from flekspy.amrex.particle_data import AMReXParticleData
-
-
-@pytest.fixture
-def mock_amrex_data():
-    """Provides a mock AMReXParticleData instance for testing."""
-    # The AMReXParticleData class requires an output_dir for initialization.
-    # We can provide a dummy path and mock any methods that would interact with the filesystem.
-    mock_data = AMReXParticleData.__new__(AMReXParticleData)
-    mock_data.header = MagicMock()  # Mock the header attribute
-    return mock_data
 
 
 @pytest.fixture
@@ -27,11 +16,11 @@ def fitted_gmm():
     return gmm
 
 
-def test_get_gmm_parameters_isotropic(mock_amrex_data, fitted_gmm):
+def test_get_gmm_parameters_isotropic(fitted_gmm):
     """
     Tests the extraction of isotropic temperature from a GMM.
     """
-    parameters = mock_amrex_data.get_gmm_parameters(fitted_gmm, isotropic=True)
+    parameters = AMReXParticleData.get_gmm_parameters(fitted_gmm, isotropic=True)
 
     assert len(parameters) == 2
 
@@ -50,11 +39,11 @@ def test_get_gmm_parameters_isotropic(mock_amrex_data, fitted_gmm):
     assert parameters[1]["temperature"] == pytest.approx(3.5)
 
 
-def test_get_gmm_parameters_bi_maxwellian(mock_amrex_data, fitted_gmm):
+def test_get_gmm_parameters_bi_maxwellian(fitted_gmm):
     """
     Tests the extraction of Bi-Maxwellian temperatures from a GMM.
     """
-    parameters = mock_amrex_data.get_gmm_parameters(fitted_gmm, isotropic=False)
+    parameters = AMReXParticleData.get_gmm_parameters(fitted_gmm, isotropic=False)
 
     assert len(parameters) == 2
 


### PR DESCRIPTION
This method extracts the centers and temperatures from a fitted Gaussian Mixture Model, supporting both isotropic and Bi-Maxwellian distributions. It includes logic to calculate a single scalar temperature for isotropic cases and parallel/perpendicular temperatures for Bi-Maxwellian cases.

A new test file with corresponding unit tests has been added to ensure the correctness of the implementation.