### PR TITLE
feat: Add marginal distribution plots to `plot_phase`

### DIFF
--- a/src/flekspy/amrex/plotting.py
+++ b/src/flekspy/amrex/plotting.py
@@ -261,7 +261,12 @@ class AMReXPlottingMixin:
         elif marginals:
             fig = plt.figure(figsize=(8, 8))
             gs = gridspec.GridSpec(
-                2, 2, width_ratios=[3, 1], height_ratios=[1, 3], hspace=0.0, wspace=0.0
+                3,
+                2,
+                width_ratios=[3, 1],
+                height_ratios=[1, 3, 0.15],
+                hspace=0.0,
+                wspace=0.0,
             )
             ax = fig.add_subplot(gs[1, 0])
             ax_histx = fig.add_subplot(gs[0, 0], sharex=ax)
@@ -355,8 +360,7 @@ class AMReXPlottingMixin:
 
         if add_colorbar:
             if marginals:
-                # Place colorbar at the bottom
-                cax = fig.add_axes([0.15, 0.08, 0.5, 0.03])
+                cax = fig.add_subplot(gs[2, 0])
                 cbar = fig.colorbar(im, cax=cax, orientation="horizontal")
             else:
                 divider = make_axes_locatable(ax)

--- a/tests/test_amrex_loader.py
+++ b/tests/test_amrex_loader.py
@@ -681,11 +681,17 @@ def test_plot_phase_with_marginals(mock_plot_components):
     mock_ax = mock_plot_components["ax"]
     mock_ax_histx = MagicMock()
     mock_ax_histy = MagicMock()
+    mock_cax = MagicMock()
 
     # Mock the gridspec and figure additions
     with patch("matplotlib.gridspec.GridSpec") as mock_gridspec:
         gs_instance = mock_gridspec.return_value
-        mock_fig.add_subplot.side_effect = [mock_ax, mock_ax_histx, mock_ax_histy]
+        mock_fig.add_subplot.side_effect = [
+            mock_ax,
+            mock_ax_histx,
+            mock_ax_histy,
+            mock_cax,
+        ]
 
         mock_pdata = MagicMock(spec=AMReXParticleData)
         mock_pdata.get_phase_space_density.return_value = (
@@ -702,16 +708,14 @@ def test_plot_phase_with_marginals(mock_plot_components):
 
         # Check for correct layout
         mock_gridspec.assert_called_once()
-        assert mock_fig.add_subplot.call_count == 3
+        assert mock_fig.add_subplot.call_count == 4
 
         # Check that the title is not set
         mock_ax.set_title.assert_not_called()
 
         # Check colorbar is at the bottom
-        mock_fig.add_axes.assert_called_once_with([0.15, 0.08, 0.5, 0.03])
-        cax = mock_fig.add_axes.return_value
         mock_fig.colorbar.assert_called_once()
-        assert mock_fig.colorbar.call_args.kwargs["cax"] is cax
+        assert mock_fig.colorbar.call_args.kwargs["cax"] is mock_cax
         assert mock_fig.colorbar.call_args.kwargs["orientation"] == "horizontal"
 
         # Check axes visibility


### PR DESCRIPTION
Adds an option to `plot_phase` to include 1D marginal histograms for the x and y axes.

When the `marginals` parameter is set to `True`:
- A `GridSpec` layout is used to create the main 2D plot and two 1D histograms.
- The 1D histograms are plotted on the top and right of the 2D histogram.
- The title of the plot is hidden.
- The colorbar is moved to the bottom with a horizontal orientation.
- The top and right axis lines of the 2D histogram are removed.