### PR TITLE
feat: Make colorbar horizontal for marginal plots

### DIFF
--- a/src/flekspy/amrex/plotting.py
+++ b/src/flekspy/amrex/plotting.py
@@ -373,10 +373,11 @@ class AMReXPlottingMixin:
         if add_colorbar:
             divider = make_axes_locatable(ax)
             if marginals:
-                cax = divider.append_axes("bottom", size="5%", pad=0.4)
+                cax = divider.append_axes("bottom", size="5%", pad=0.5)
+                cbar = fig.colorbar(im, cax=cax, orientation="horizontal")
             else:
                 cax = divider.append_axes("right", size="3%", pad=0.05)
-            cbar = fig.colorbar(im, cax=cax)
+                cbar = fig.colorbar(im, cax=cax)
             cbar.set_label(cbar_label)
 
         # --- 4. Return the plot objects ---

--- a/tests/test_amrex_loader.py
+++ b/tests/test_amrex_loader.py
@@ -706,10 +706,12 @@ def test_plot_phase_with_marginals(mock_plot_components, mock_pdata):
 
         # Check colorbar is at the bottom using the divider
         mock_plot_components["make_axes_locatable"].assert_called_once_with(mock_ax)
-        mock_divider.append_axes.assert_called_once_with("bottom", size="5%", pad=0.4)
+        mock_divider.append_axes.assert_called_once_with("bottom", size="5%", pad=0.5)
 
         mock_fig.colorbar.assert_called_once()
         assert mock_fig.colorbar.call_args.kwargs["cax"] is mock_cax
+        assert "orientation" in mock_fig.colorbar.call_args.kwargs
+        assert mock_fig.colorbar.call_args.kwargs["orientation"] == "horizontal"
 
         # Check axes visibility
         mock_ax.spines["top"].set_visible.assert_called_with(False)


### PR DESCRIPTION
Makes the colorbar orientation horizontal for the marginal plot in `plot_phase` of the amrex module, and leaves enough space to avoid overlapping with the xlabel.