### PR TITLE
Refactor: Remove end_char attribute from IDL loader

### DIFF
--- a/src/flekspy/idl/idl.py
+++ b/src/flekspy/idl/idl.py
@@ -318,7 +318,7 @@ def _read_parameters(infile, attrs, end_char):
     new_attrs = {}
     new_attrs["parameters"] = np.zeros(attrs["nparam"])
     if attrs["nparam"] > 0:
-        (old_len, record_len) = struct.unpack(f"{end_char}2l", infile.read(8))
+        (_, record_len) = struct.unpack(f"{end_char}2l", infile.read(8))
         new_attrs["parameters"][:] = struct.unpack(
             f"{end_char}{attrs['nparam']}{attrs['pformat']}",
             infile.read(record_len),


### PR DESCRIPTION
This commit refactors the IDL data loader to remove the `end_char` attribute from the user-facing attributes dictionary.

The endianness of the file is now determined once and passed as a parameter to the internal parsing functions, rather than being stored in the `attrs` dictionary. This makes the code cleaner and avoids exposing internal implementation details to the user.