### PR TITLE
Refactor: Remove endian attribute and add comment

### DIFF
--- a/src/flekspy/idl/idl.py
+++ b/src/flekspy/idl/idl.py
@@ -202,7 +202,9 @@ def _get_file_head(infile, attrs):
         record_len_raw = infile.read(4)
         record_len = struct.unpack("<l", record_len_raw)[0]
 
-        # Check for endianness.
+        # Heuristic check for file endianness. Assumes little-endian, but if the
+        # first record length is unreasonably large or negative, it switches to
+        # big-endian. This is a common pattern for FORTRAN-style binary files.
         if (record_len > 10000) or (record_len < 0):
             end_char = ">"
             record_len = struct.unpack(">l", record_len_raw)[0]


### PR DESCRIPTION
This commit refactors the IDL data loader to remove the 'endian' attribute from the user-facing dataset attributes, as it's an internal implementation detail. A comment has been added to the endianness check to clarify its purpose.