### PR TITLE
Refactor: Make `pformat` an internal variable in IDL loader

### DIFF
--- a/src/flekspy/idl/idl.py
+++ b/src/flekspy/idl/idl.py
@@ -134,8 +134,7 @@ def _read_and_process_data(filename):
                 data_vars[var_name] = (dims, np.squeeze(data_slice))
 
         dataset = xr.Dataset(data_vars, coords=coords)
-    if "pformat" in attrs:
-        del attrs["pformat"]
+    attrs.pop("pformat", None)
     dataset.attrs = attrs
     # TODO: Implement a more robust unit handling system.
     return dataset


### PR DESCRIPTION
The `pformat` attribute, used to determine the floating-point precision of binary IDL files, is an internal implementation detail of the file parser.

This commit removes the `pformat` attribute from the final `xarray.Dataset`'s `attrs` dictionary. This prevents cluttering the dataset's metadata with information that is not relevant to the user, who can infer the data type directly from the loaded arrays.