### PR TITLE
Docs: Add anisotropic GMM example

### DIFF
--- a/docs/amrex_data.ipynb
+++ b/docs/amrex_data.ipynb
@@ -784,9 +784,9 @@
     "print(\\\"\\\\n--- GMM Extracted Anisotropic Parameters ---\\\")\\n",
     "for i, params in enumerate(extracted_params_aniso):\\n",
     "    center = [round(c, 5) for c in params[\\\"center\\\"]]\\n",
-    "    temp_par = round(params[\\\"temp_parallel\\\"], 5)\\n",
-    "    temp_per = round(params[\\\"temp_perp\\\"], 5)\\n",
-    "    print(f\\\"Component {i+1}: Center = {center}, Temp Parallel = {temp_par}, Temp Perp = {temp_per}\\\")"
+    "    temp_par_ext = round(params[\\\"T_parallel\\\"], 5)\\n",
+    "    temp_per_ext = round(params[\\\"T_perpendicular\\\"], 5)\\n",
+    "    print(f\\\"Component {i+1}: Center = {center}, Temp Parallel = {temp_par_ext}, Temp Perp = {temp_per_ext}\\\")"
    ]
   },
   {
@@ -795,8 +795,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib.patches import Ellipse\\n",
-    "\\n",
     "fig, ax = plt.subplots(figsize=(8, 8))\\n",
     "\\n",
     "# Plot the 2D histogram of the synthetic anisotropic data\\n",


### PR DESCRIPTION
Adds an example of GMM fitting for anisotropic data to the AMReX documentation notebook.

This new section includes:
- Generation of synthetic anisotropic data.
- Fitting a GMM to the data.
- Extracting and verifying the physical parameters.
- Visualization of the results.