### PR TITLE
feat: Update GMM temperature conversion to use AMU

### DIFF
--- a/tests/test_gmm_parameters.py
+++ b/tests/test_gmm_parameters.py
@@ -20,45 +20,54 @@ def test_get_gmm_parameters_isotropic(fitted_gmm):
     """
     Tests the extraction of isotropic temperature from a GMM.
     """
-    parameters = AMReXParticleData.get_gmm_parameters(fitted_gmm, isotropic=True)
+    from scipy.constants import m_u, k
+
+    # Test with explicit particle_mass in amu
+    parameters = AMReXParticleData.get_gmm_parameters(
+        fitted_gmm, particle_mass=1.0, isotropic=True
+    )
 
     assert len(parameters) == 2
+    # v_th_sq_1 = (1.0 + 2.0) / 2.0 = 1.5
+    # T_1 = (1.0 * m_u) * v_th_sq_1 / k
+    expected_temp_1 = 1.0 * m_u * 1.5 / k
+    assert parameters[0]["temperature"] == pytest.approx(expected_temp_1)
 
-    # Component 1
-    assert "center" in parameters[0]
-    assert "temperature" in parameters[0]
-    np.testing.assert_almost_equal(parameters[0]["center"], [0.0, 1.0])
-    # T = (1.0 + 2.0) / 2.0 = 1.5
-    assert parameters[0]["temperature"] == pytest.approx(1.5)
+    # v_th_sq_2 = (3.0 + 4.0) / 2.0 = 3.5
+    # T_2 = (1.0 * m_u) * v_th_sq_2 / k
+    expected_temp_2 = 1.0 * m_u * 3.5 / k
+    assert parameters[1]["temperature"] == pytest.approx(expected_temp_2)
 
-    # Component 2
-    assert "center" in parameters[1]
-    assert "temperature" in parameters[1]
-    np.testing.assert_almost_equal(parameters[1]["center"], [2.0, 3.0])
-    # T = (3.0 + 4.0) / 2.0 = 3.5
-    assert parameters[1]["temperature"] == pytest.approx(3.5)
+    # Test with default particle_mass (should be 1.0 amu)
+    parameters_default = AMReXParticleData.get_gmm_parameters(
+        fitted_gmm, isotropic=True
+    )
+    assert parameters_default[0]["temperature"] == pytest.approx(expected_temp_1)
+    assert parameters_default[1]["temperature"] == pytest.approx(expected_temp_2)
 
 
 def test_get_gmm_parameters_bi_maxwellian(fitted_gmm):
     """
-    Tests the extraction of Bi-Maxwellian temperatures from a GMM.
+    Tests the extraction of Bi-Maxwellian temperatures from a GM.
     """
-    parameters = AMReXParticleData.get_gmm_parameters(fitted_gmm, isotropic=False)
+    from scipy.constants import m_u, k
+
+    parameters = AMReXParticleData.get_gmm_parameters(
+        fitted_gmm, particle_mass=1.0, isotropic=False
+    )
 
     assert len(parameters) == 2
 
-    # Component 1
-    assert "center" in parameters[0]
-    assert "T_parallel" in parameters[0]
-    assert "T_perpendicular" in parameters[0]
-    np.testing.assert_almost_equal(parameters[0]["center"], [0.0, 1.0])
-    assert parameters[0]["T_parallel"] == pytest.approx(1.0)
-    assert parameters[0]["T_perpendicular"] == pytest.approx(2.0)
+    # T_par_1 = (1.0 * m_u) * 1.0 / k
+    expected_t_par_1 = 1.0 * m_u * 1.0 / k
+    # T_perp_1 = (1.0 * m_u) * 2.0 / k
+    expected_t_perp_1 = 1.0 * m_u * 2.0 / k
+    assert parameters[0]["T_parallel"] == pytest.approx(expected_t_par_1)
+    assert parameters[0]["T_perpendicular"] == pytest.approx(expected_t_perp_1)
 
-    # Component 2
-    assert "center" in parameters[1]
-    assert "T_parallel" in parameters[1]
-    assert "T_perpendicular" in parameters[1]
-    np.testing.assert_almost_equal(parameters[1]["center"], [2.0, 3.0])
-    assert parameters[1]["T_parallel"] == pytest.approx(3.0)
-    assert parameters[1]["T_perpendicular"] == pytest.approx(4.0)
+    # T_par_2 = (1.0 * m_u) * 3.0 / k
+    expected_t_par_2 = 1.0 * m_u * 3.0 / k
+    # T_perp_2 = (1.0 * m_u) * 4.0 / k
+    expected_t_perp_2 = 1.0 * m_u * 4.0 / k
+    assert parameters[1]["T_parallel"] == pytest.approx(expected_t_par_2)
+    assert parameters[1]["T_perpendicular"] == pytest.approx(expected_t_perp_2)


### PR DESCRIPTION
This commit refactors the `get_gmm_parameters` method to improve usability based on user feedback. The `particle_mass` parameter is now specified in atomic mass units (amu) instead of kilograms, and a default value of 1.0 amu has been added.

Key changes:
- The `particle_mass` parameter in `get_gmm_parameters` now defaults to `1.0`.
- The docstring has been updated to clarify that the particle mass should be provided in amu.
- The internal logic now converts the mass from amu to kg using `scipy.constants.m_u` before performing the temperature calculation.
- The tests have been updated to align with these changes, including a case to verify the new default behavior.

This makes the method more convenient for users, as particle masses are commonly expressed in amu in this domain.